### PR TITLE
escaping citation with escapejs instead of safe. fixes #16

### DIFF
--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -51,7 +51,7 @@
         };
         console.log("sending message to receiver: ", message, receiver);
         window.parent.postMessage(JSON.stringify(message), receiver);
-    }, 1000); 
+    }, 1000);
 </script>
 
 <div class="container fit-to-canvas">
@@ -115,7 +115,7 @@ jQuery(function ($) {
 						//'Touch',
 					],
 					'database_url': "{{ abstract_db_url }}", //"{{ assignment.annotation_database_url }}",
-					'citation': "{{ target_object.target_citation | safe }}",
+					'citation': "{{ target_object.target_citation | escapejs }}",
 					{% if assignment.allow_highlights %}
 					'higlightTags_options': "{{ assignment.highlights_options }}",
 					{% endif %}
@@ -140,7 +140,7 @@ jQuery(function ($) {
 		if (typeof Annotator.Plugin["Grouping"] === 'function') {
 			options = {
 	    		optionsOVA: {
-		    		posBigNew: 'none', 
+		    		posBigNew: 'none',
 		    		default_tab: 'Public',
 		    		annotation_tool: AController.annotationCore.annotation_tool,
 		    	}


### PR DESCRIPTION
The citation data was being escaped using safe, which only escapes to HTML encoding. But Citation was being included as json data, and so needs to be escaped with escapejs.

This fixes #16 