### PR TITLE
feature/reply-button-position

### DIFF
--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -586,7 +586,6 @@
     		var replies_offset = jQuery('.parentAnnotation').offset().top -jQuery('.annotationModal').offset().top + jQuery('.parentAnnotation').height();
     		var replies_height = jQuery(window).height() - jQuery('.replybutton').height() - jQuery('.parentAnnotation').height() - jQuery('.modal-navigation').height();
     		jQuery('.repliesList').css('margin-top', replies_offset);
-    		jQuery('.repliesList').css('height', replies_height);
     		var final_html = '';
     		self.list_of_replies = {}
     		annotations.forEach(function(annotation) {
@@ -596,6 +595,16 @@
 				self.list_of_replies[item.id.toString()] = annotation;
 			});
 			jQuery('.repliesList').html(final_html);
+
+			// when there are too many replies to show on the screen at once,
+			// "fix" the position of the list so the height is constant and it's scrollable
+			// while positioning the reply button at the bottom of the screen so that it's
+			// always visible and available.
+			//		--abarrett 10/6/15
+			if(jQuery('.repliesList').height() > replies_height) {
+				jQuery('.repliesList').css('height', replies_height);
+				jQuery('.addReply').addClass('addReplyFixedPosition');
+			}
     	}
 
     	var search_url = store._urlFor("search", annotation_id);

--- a/hx_lti_initializer/static/css/dashboard.css
+++ b/hx_lti_initializer/static/css/dashboard.css
@@ -241,9 +241,11 @@ button#closeModal {
 }
 
 .addReply {
+    width: 100%;
+}
+.addReplyFixedPosition {
     position: absolute;
     bottom: 0;
-    width: 100%;
 }
 
 .addReply button.btn.btn-primary.replybutton {
@@ -253,8 +255,8 @@ button#closeModal {
 .repliesList {
     text-align: center;
     padding-top: 25px;
-    padding-bottom: 45px;
-    height: inherit;
+    /* padding-bottom: 45px; */
+    /* height: inherit; */
     overflow-y: scroll;
 }
 


### PR DESCRIPTION
Modified the annotation reply UI so that the reply button is easier to find and use.

Instead of this (reply button all the way at the bottom, off screen sometimes):

![screen shot 2015-10-06 at 2 33 59 pm](https://cloud.githubusercontent.com/assets/1165361/10318416/502acbac-6c37-11e5-8b1e-bde66e71349a.png)

It's now displayed like this (immediately after the most recent comment, easily visible):

![screen shot 2015-10-06 at 2 29 37 pm](https://cloud.githubusercontent.com/assets/1165361/10318421/5b67f120-6c37-11e5-8204-d8a8b1e70c7e.png)

Or like this (fixed at the bottom of the screen when there are lots of comments):

![screen shot 2015-10-06 at 2 32 41 pm](https://cloud.githubusercontent.com/assets/1165361/10318427/648505ae-6c37-11e5-9fa3-6b7597cd24f5.png)

Fixes https://github.com/Harvard-ATG/annotationsx/issues/32

@jazahn review?