### PR TITLE
feature/sort-dropdowns

### DIFF
--- a/hx_lti_initializer/forms.py
+++ b/hx_lti_initializer/forms.py
@@ -1,9 +1,16 @@
 from django import forms
-from hx_lti_initializer.models import LTICourse
+from hx_lti_initializer.models import LTICourse, LTIProfile
 from hx_lti_assignment.models import Assignment
 
 class CourseForm(forms.ModelForm):
+	
+	def __init__(self, *args, **kwargs):
+		super(CourseForm, self).__init__(*args, **kwargs)
+		self.fields['course_admins'].queryset = self.get_course_admins()
 
+	def get_course_admins(self):
+		return LTIProfile.objects.select_related('user').order_by('user__first_name', 'user__last_name', 'user__username')
+	
 	class Meta:
 		model = LTICourse
 		fields = ('course_name', 'course_admins', 'course_external_css_default')

--- a/hx_lti_initializer/tests.py
+++ b/hx_lti_initializer/tests.py
@@ -370,6 +370,10 @@ class LTIInitializerCourseFormTests(TestCase):
         self.course = course
         self.course_form = CourseForm(instance=course)
     
+    def tearDown(self):
+        User.objects.filter(pk__in=[u.id for u in self.course_admins]).delete()
+        self.course.delete()
+    
     def test_course_form_admins(self):
         course_admins_queryset = self.course_form.get_course_admins().all()
         given_course_admin_names = [(profile.user.first_name, profile.user.last_name) for profile in course_admins_queryset]


### PR DESCRIPTION
This PR fixes a sorting issue with the "coures_admins" drop-down menu when editing course settings. The issue was that admins weren't listed in any particular order, so it was hard to find people. This modifies it so that admins are ordered by first and last name.

@jazahn review?