### PR TITLE
Instructor Dashboard: Async Load Annotations

### DIFF
--- a/hx_lti_initializer/static/css/base.css
+++ b/hx_lti_initializer/static/css/base.css
@@ -226,3 +226,40 @@ footer {
     -webkit-margin-before: 0em;
     -webkit-padding-start: 0px;
 }
+
+.spin {
+  -webkit-animation: spin .5s infinite linear;
+  -moz-animation: spin .5s infinite linear;
+  -o-animation: spin .5s infinite linear;
+  animation: spin .5s infinite linear;
+     -webkit-transform-origin: 50% 58%;
+         transform-origin:50% 58%;
+         -ms-transform-origin:50% 58%; /* IE 9 */
+}
+
+@-moz-keyframes spin {
+  from {
+    -moz-transform: rotate(0deg);
+  }
+  to {
+    -moz-transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes spin {
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_student_list_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_student_list_view.html
@@ -1,0 +1,52 @@
+{% if user_annotations %}
+{% for user in user_annotations %}
+<div class="panel-group" id="accordion">
+    <div class="panel panel-default">
+        <div data-toggle="collapse" data-parent="#accordion" href="#userpanel-{{ forloop.counter }}" class="panel-heading list-group-item" style="cursor: pointer;">
+            <h4 class="panel-title">{{ user.name }} ({{user.total_annotations}})</h4>
+        </div>
+        <div id="userpanel-{{ forloop.counter }}" class="panel-collapse collapse">
+            <div class="panel-body">
+                    <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th class="col-md-1">Date</th><!-- Only Date isn't of variable length -->
+                            <th>Assignment</th>
+                            <th>Object</th>
+                            <th>Excerpt</th>
+                            <th>Annotation</th>
+                            <th>Tags</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for annotation in user.annotations %}
+                        <tr>
+                            <td>{{ annotation.data.updated | format_date }}</td> 
+                            <td>{{ annotation.assignment_name }}</td>
+                            <td><a href="{{ annotation.target_preview_url  }}">{{ annotation.target_object_name }}</a></td>
+                            <td>
+                                {% if annotation.data.parent == "0" %}
+                                    {% if annotation.data.media == "text" %}
+                                        "{{ annotation.data.quote }}"
+                                    {% else %}
+                                        <img class="lazy" data-original="{{annotation.data.thumb}}" width="{{annotation.data.rangePosition.width}}" height="{{annotation.data.rangePosition.height}}" style="max-width:150px; max-height:150px;" />
+                                    {% endif %}
+                                {% else %}
+                                    <b>Reply To:</b> "{{ annotation.parent_text }}"
+                                {% endif %}
+                            </td>
+                            <td>{{ annotation.data.text | safe }}</td>
+                            <td>{{ annotation.data.tags | format_tags }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endfor %}
+{% else %}
+<div style="margin: 1em 0;">No annotations to display</div>
+{% endif %}
+<div style="color: #999; font-size: 11px; float: right;"><i>Fetched annotations in {{fetch_annotations_time|floatformat:4}} seconds.</i></div>

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -11,152 +11,116 @@
 
 
 {% block content %}
-{% if user_annotations %}
-	<div style="margin: 1em 0;">
-		<div class="input-group">
-			<div class="input-group-btn search-panel">
-				<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-					<span id="search_concept">By Name</span> <span class="caret"></span>
-				</button>
-				<ul class="dropdown-menu" role="menu">
-					<li><a href="#name">By Name</a></li>
-					<li><a href="#content">By Content</a></li>
-				</ul>
-			</div>
-			<input type="text" id="studentsearch" class="form-control" placeholder="Search text...">
-			<input type="hidden" name="search_param" value="name" id="search_param">
+<div style="margin: 1em 0; padding: 1em 0;">
+	<div class="input-group">
+		<div class="input-group-btn search-panel">
+			<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+				<span id="search_concept">By Name</span> <span class="caret"></span>
+			</button>
+			<ul class="dropdown-menu" role="menu">
+				<li><a href="#name">By Name</a></li>
+				<li><a href="#content">By Content</a></li>
+			</ul>
 		</div>
-		<div id="student_list" class="list-group">
-			<br/>
-			{% for user in user_annotations %}
-			<div>
-				<div class="panel-group" id="accordion">
-					<div class="panel panel-default">
-						<div data-toggle="collapse" data-parent="#accordion" href="#userpanel-{{ forloop.counter }}" class="panel-heading list-group-item" style="cursor: pointer;">
-							<h4 class="panel-title">
-								{{ user.name }} ({{user.total_annotations}})
-							</h4>
-						</div>
-						<div id="userpanel-{{ forloop.counter }}" class="panel-collapse collapse">
-							<div class="panel-body">
-									<table class="table table-hover">
-									<thead>
-										<tr>
-											<th class="col-md-1">Date</th><!-- Only Date isn't of variable length -->
-											<th>Assignment</th>
-											<th>Object</th>
-											<th>Excerpt</th>
-											<th>Annotation</th>
-											<th>Tags</th>
-										</tr>
-									</thead>
-									<tbody>
-										{% for annotation in user.annotations %}
-										<tr>
-											<td>{{ annotation.data.updated | format_date }}</td> 
-											<td>{{ annotation.assignment_name }}</td>
-											<td><a href="{{ annotation.target_preview_url  }}">{{ annotation.target_object_name }}</a></td>
-											<td>
-												{% if annotation.data.parent == "0" %}
-													{% if annotation.data.media == "text" %}
-														"{{ annotation.data.quote }}"
-													{% else %}
-														<img class="lazy" data-original="{{annotation.data.thumb}}" width="{{annotation.data.rangePosition.width}}" height="{{annotation.data.rangePosition.height}}" style="max-width:150px; max-height:150px;" />
-													{% endif %}
-												{% else %}
-													<b>Reply To:</b> "{{ annotation.parent_text }}"
-												{% endif %}
-											</td>
-											<td>{{ annotation.data.text | safe }}</td>
-											<td>{{ annotation.data.tags | format_tags }}</td>
-										</tr>
-										{% endfor %}
-									</tbody>
-								</table>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-			{% endfor %}
-		</div>
-{% else %}
-	<div style="margin: 1em 0;">No annotations to display</div>
-{% endif %}
-<div style="color: #999; font-size: 11px; float: right;"><i>Loaded annotations in {{fetch_annotations_time|floatformat:4}} seconds.</i></div>
+		<input type="text" id="studentsearch" class="form-control" placeholder="Search text...">
+		<input type="hidden" name="search_param" value="name" id="search_param">
+	</div>
+	<div id="student_list_loading" style="margin: 1em; text-align: center;">
+		<span class="glyphicon glyphicon-refresh spin"></span> Loading student annotations...
+	</div>
+	<div id="student_list" class="list-group" style="padding: 1em 0">
+		{% if user_annotations %}
+			{% include "hx_lti_initializer/dashboard_student_list_view.html" with user_annotations=user_annotations %}
+		{% endif %}
+	</div>
 {% endblock %}
 
 
 {% block javascript %}
 <script src="{% static "vendors/development/jquery.lazyload.js" %}"></script>
 <script>
+var DASHBOARD_CTX = {{dashboard_context_js|safe}};
+
 $(document).ready(function() {
+
 	//------------------------
-	// Lazy-load thumbnail images.
-	// Triggers the lazy load when a panel is clicked.
-	$('img.lazy').lazyload({
-		event: "panelClick",
-		effect: "fadeIn"
-	});
-	$('.panel').on('click', function(evt) {
-		$("img.lazy", evt.currentTarget).trigger("panelClick");
+	// Async-load the annotations data.
+	$.ajax(DASHBOARD_CTX.student_list_view_url, {
+		dataType: "html",
+		beforesend: function(xhr) {
+			$("#student_list_loading").show();
+		},
+		complete: function(xhr, textStatus) {
+			$("#student_list_loading").hide();
+		},
+		success: function(data) {
+			$("#student_list").html(data);
+			setup_dashboard_search();
+			setup_image_lazy_load();
+		},
+		error: function(xhr, textStatus) {
+			$("#student_list").html("Error loading data: " + textStatus)
+		}
 	});
 	
 	//------------------------
+	// Lazy-load thumbnail images.
+	// Triggers the lazy load when a panel is clicked.
+	function setup_image_lazy_load() {
+		$('img.lazy').lazyload({
+			event: "panelClick",
+			effect: "fadeIn"
+		});
+		$('.panel').on('click', function(evt) {
+			$("img.lazy", evt.currentTarget).trigger("panelClick");
+		});
+	}
+
+	//------------------------
 	// Search functionality.
-    var type = 'name'; // Search type (name by default)
-    var $panels = $('.panel'); // Get all panels 
-    
-    // Handles toggling for search bar dropdown
-    $('.search-panel .dropdown-menu').find('a').click(function(e) {
-        e.preventDefault();
-        var param = $(this).attr("href").replace("#", "");
-        var concept = $(this).text();
-        $('.search-panel span#search_concept').text(concept);
-        $('.input-group #search_param').val(param);
-        // Update search type
-        type = param;
-        // Update view
-        update($('#studentsearch').val().toLowerCase());
-        
-    });
-    
-    // Search on key press
-    $('#studentsearch').on('keyup', function(e){
-        var val = this.value.toLowerCase();
-        
-        // Only trigger if alphanumeric character is entered
-        if ((e.which <= 90 && e.which >= 48)) {
-            update(val);
-        }
-        
-        // Collapse and show all panels
-        else if (val == '') {
-            $panels.show();
-            $('.panel-collapse').collapse('hide');
-        }
-    });
-    
-    // Updates view
-    function update(value) {
-        // lookup table for search type
-        var selector_for = {
-          'name': '.panel-title',
-          'content': '.panel-body'
-        };
-        
-        // match search type to selector
-        var selector = selector_for[type];
-        
-        if (selector && value != '') {
-            // Show panels that match user
-            $panels.show().filter(function(){
-                $('.panel-collapse').collapse('show');
-                var title = $(this).find(selector).text().toLowerCase();
-                return title.indexOf(value) < 0;
-            }).hide();
-        }
-    }
+	function setup_dashboard_search() {
+		var type = 'name'; // Search type (name by default)
+		var update = function(value) {
+			var selector_for = {'name': '.panel-title', 'content': '.panel-body'};
+			var selector = selector_for[type];
+			if (selector && value != '') {
+				// Show panels that match user
+				$('.panel').show().filter(function(){
+					$('.panel-collapse').collapse('show');
+					var title = $(this).find(selector).text().toLowerCase();
+					return title.indexOf(value) < 0;
+				}).hide();
+			}
+		};
+
+		// Handles toggling for search bar dropdown
+		$('.search-panel .dropdown-menu').find('a').click(function(e) {
+			e.preventDefault();
+			var param = $(this).attr("href").replace("#", "");
+			var concept = $(this).text();
+			$('.search-panel span#search_concept').text(concept);
+			$('.input-group #search_param').val(param);
+			// Update search type
+			type = param;
+			// Update view
+			update($('#studentsearch').val().toLowerCase());
+			
+		});
+		
+		// Search on key press
+		$('#studentsearch').on('keyup', function(e){
+			var val = this.value.toLowerCase();
+			// Only trigger if alphanumeric character is entered
+			if ((e.which <= 90 && e.which >= 48)) {
+				update(val);
+			}
+			// Collapse and show all panels
+			else if (val == '') {
+				$('.panel').show();
+				$('.panel-collapse').collapse('hide');
+			}
+		});		
+	}
 });
 </script>
 {% endblock %}

--- a/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
+++ b/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from datetime import datetime
 from dateutil import tz
 from django import template
-from django.core.urlresolvers import reverse
 from django.template.defaultfilters import stringfilter
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from re import sub

--- a/hx_lti_initializer/urls.py
+++ b/hx_lti_initializer/urls.py
@@ -57,7 +57,7 @@ urlpatterns = patterns(
     ),
     # using a wildcard for the middle of the url, so lti_init/instructor_dashboard and lti_init/admin_hub/instructor_dashboard will both work
     url(r'\w/instructor_dashboard_view$', 'hx_lti_initializer.views.instructor_dashboard_view', name='instructor_dashboard_view'),
-
+    url(r'\w/instructor_dashboard_view/student_list$', 'hx_lti_initializer.views.instructor_dashboard_student_list_view', name='instructor_dashboard_student_list_view'),
     url(
         r'^delete_assignment/$',
         'hx_lti_initializer.views.delete_assignment',


### PR DESCRIPTION
This PR modifies the instructor dashboard view so that annotations are loaded asynchronously. 

The reason for this change is that fetching the annotations from the CATCH database and rendering them can be quite slow depending on how many annotations there are, so this will improve the user's perception of the performance.

@jazahn Review?