### PR TITLE
DO NOT MERGE -- Annotation Permissions

### DIFF
--- a/hx_lti_initializer/annotation_database.py
+++ b/hx_lti_initializer/annotation_database.py
@@ -8,7 +8,7 @@ def process_search_response(data, user_id=None, has_read_perm=False):
     if has_read_perm is True:
         return data
 
-    # If we get here, that means the user has no special permissions (i.e instructor, staff, etc)
+    # If we get here, that means the user has no special permissions (i.e user is NOT instructor, staff, etc)
     # and they are using a non-HarvardX instance of the tool (i.e. ATG instance).
     # The code below checks the "read" permissions to return only the annotation(s) that the user
     # is authorized to read.

--- a/hx_lti_initializer/annotation_database.py
+++ b/hx_lti_initializer/annotation_database.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+
+def process_search_response(data, user_id=None, has_read_perm=False):
+    if settings.ORGANIZATION  != "ATG":
+        return data
+    if user_id is None:
+        return data
+    if has_read_perm is True:
+        return data
+
+    # If we get here, that means the user has no special permissions (i.e instructor, staff, etc)
+    # and they are using a non-HarvardX instance of the tool (i.e. ATG instance).
+    # The code below checks the "read" permissions to return only the annotation(s) that the user
+    # is authorized to read.
+    authorized_data = {
+        'total': 0,
+        'limit': data['limit'],
+        'offset': data['offset'],
+        'rows': [],
+    }
+
+    for row in data['rows']:
+        no_permissions = not ('permissions' in row and 'read' in row['permissions'])
+        read_permissions = row['permissions']['read']
+        if no_permissions or len(read_permissions) == 0 or user_id in read_permissions:
+            authorized_data['rows'].append(row)
+
+    authorized_data['total'] = len(authorized_data['rows'])
+    
+    return authorized_data

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -139,7 +139,7 @@
 	                        'delete': [this.initOptions.user_id,],
 	                        'admin':  [this.initOptions.user_id,]
 	                },
-	                showViewPermissionsCheckbox: true,
+	                showViewPermissionsCheckbox: this.initOptions.showViewPermissionsCheckbox || false,
 	                showEditPermissionsCheckbox: false,
 	                userString: function (user) {
 	                    if (user && user.name)

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -139,7 +139,7 @@
 	                        'delete': [this.initOptions.user_id,],
 	                        'admin':  [this.initOptions.user_id,]
 	                },
-	                showViewPermissionsCheckbox: false,
+	                showViewPermissionsCheckbox: true,
 	                showEditPermissionsCheckbox: false,
 	                userString: function (user) {
 	                    if (user && user.name)

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -117,6 +117,7 @@ Annotation Tool | Text | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
+      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true{% else %}false{% endif %}
     },
   };
 {% endblock %}


### PR DESCRIPTION
**DO NOT MERGE!**

---

**Note:** this PR is not intended to be merged *unless* [CATCH](https://github.com/annotationsatharvard/catcha)-side permission checking isn't available for deployment testing by Thursday, February 11th (ideally, Wednesday). We need to have this functionality deployed to production by Friday, Wednesday 12th, so this PR is our backup plan if absolutely necessary.

**See also:** https://github.com/annotationsatharvard/catcha/issues/70

---

**Synopsis:** This PR implements a simple backend method to check annotation view permissions so that users can create "private" annotations that only teaching staff can read. To make annotations private, users simply uncheck *Allow anyone to view this annotation* when creating an annotation (public by default). 

![annotatorpermission](https://cloud.githubusercontent.com/assets/1165361/12894373/4fad57d2-ce64-11e5-8b3b-63b24c2062fe.png)

Since all [CATCH database](https://github.com/annotationsatharvard/catcha) search requests are proxied by the django backend, this PR introduces a filter on the response that checks the `read: []` permissions. One limitation of this is that if the client requests a specific number of annotations for pagination purposes (i.e. `offset: 20, limit: 20`), and the [CATCH database](https://github.com/annotationsatharvard/catcha) returns `total == limit` annotations, then it's possible that `total < limit` after the permissions are applied. A workaround is to make the `limit` high so that in practice, it doesn't become an issue. For our purposes, this is probably sufficient, but it highlights one of the reasons why the proper solution is to implement permission checking in the [CATCH database](https://github.com/annotationsatharvard/catcha) itself, and this should be considered a short-term solution at best.

@MichaelDHilborn-Harvard Review?

---
**DO NOT MERGE!**