### PR TITLE
feature/enable-permissions

### DIFF
--- a/hx_lti_initializer/annotation_database.py
+++ b/hx_lti_initializer/annotation_database.py
@@ -1,0 +1,49 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+ADMIN_GROUP_ID = '__admin__'
+
+def update_read_permissions(data):
+    '''
+    Given an annotation data object, update the "read" permissions so that
+    course admins can view private annotations.
+    
+    Instead of adding the specific user IDs of course admins, a group identifier is used
+    so that the IDs aren't hard-coded, which would require updating if the list of admins
+    changes in the tool. It's expected that when the tool searchs the annotation database on
+    behalf of a course admin, it will use the admin group identifier.
+    
+    Possible read permissions:
+       - permissions.read = []                        # world-readable (public)
+       - permissions.read = [user_id]                 # private (user only)
+       - permissions.read = [user_id, ADMIN_GROUP_ID] # semi-private (user + admins only)
+    
+    '''
+    logger.debug("update_read_permissions(): %s" % json.dumps(data, sort_keys=True, indent=4, separators=(',', ': ')))
+    has_permissions = ('permissions' in data and 'read' in data['permissions'])
+    if not has_permissions:
+        return data
+
+    # Do nothing if the annotation is world-readable
+    if len(data['permissions']['read']) == 0:
+        return data
+    
+    has_parent = ('parent' in data and data['parent'] != '' and data['parent'] != '0')
+    if has_parent:
+        # This is here to ensure that when a reply is created, it remains visible to the
+        # author of the parent annotation, even if the reply has unchecked "Allow anyone to view
+        # this annotation" in the annotator editor. Ideally, the annotator UI field should either 
+        # be removed from the annotator editor for replies, or work as expected. That is, when checked, 
+        # only the annotation author, reply author, and thread participants have read permission. 
+        data['permissions']['read'] = []
+        logger.debug("update_read_permissions(): reply: %s" % data['permissions']['read'])
+    else:
+        # Ensure the annotation is readable by course admins
+        read_permissions = data['permissions']['read']
+        if ADMIN_GROUP_ID not in read_permissions:
+            read_permissions.append(ADMIN_GROUP_ID)
+            logger.debug("update_read_permissions(): annotation: %s" % read_permissions)
+
+    return data

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -139,7 +139,7 @@
 	                        'delete': [this.initOptions.user_id,],
 	                        'admin':  [this.initOptions.user_id,]
 	                },
-	                showViewPermissionsCheckbox: false,
+	                showViewPermissionsCheckbox: this.initOptions.showViewPermissionsCheckbox || false,
 	                showEditPermissionsCheckbox: false,
 	                userString: function (user) {
 	                    if (user && user.name)

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -117,6 +117,7 @@ Annotation Tool | Text | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
+      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true{% else %}false{% endif %}
     },
   };
 {% endblock %}

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -193,6 +193,15 @@ def retrieve_token(userid, apikey, secret):
 
     return token
 
+def get_admin_ids(context_id):
+    """
+        Returns a set of the user ids of all users with an admin role
+    """
+    course_object = LTICourse.get_course_by_id(context_id)
+    admins = course_object.course_admins.all()
+    admin_ids = [admin.get_id() for admin in admins]
+
+    return admin_ids
 
 class simple_utc(datetime.tzinfo):
     def tzname(self):

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -25,7 +25,8 @@ from hx_lti_initializer.models import LTIProfile, LTICourse, User
 from hx_lti_assignment.models import Assignment, AssignmentTargets
 from hx_lti_initializer.forms import CourseForm
 from hx_lti_initializer.utils import (debug_printer, get_lti_value, retrieve_token, save_session,create_new_user, initialize_lti_tool_provider,
-    validate_request, fetch_annotations_by_course, DashboardAnnotations)
+    validate_request, fetch_annotations_by_course, get_admin_ids, DashboardAnnotations)
+from hx_lti_initializer import annotation_database
 from django.conf import settings
 from abstract_base_classes.target_object_database_api import TOD_Implementation
 from django.contrib.sites.models import get_current_site
@@ -387,7 +388,7 @@ def instructor_dashboard_student_list_view(request):
     
     # Fetch the annotations and time how long the request takes
     fetch_start_time = time.time()
-    course_annotations = fetch_annotations_by_course(context_id, user_id)
+    course_annotations = fetch_annotations_by_course(context_id, annotation_database.ADMIN_GROUP_ID)
     fetch_end_time = time.time()
     fetch_elapsed_time = fetch_end_time - fetch_start_time
 
@@ -458,6 +459,7 @@ def annotation_database_search(request):
     '''
     session_collection_id = request.session['hx_collection_id']
     session_context_id = request.session['hx_context_id']
+    session_is_staff = request.session['is_staff']
 
     request_collection_id = request.GET.get('collectionId', None)
     request_context_id = request.GET.get('contextId', None)
@@ -474,9 +476,18 @@ def annotation_database_search(request):
     headers = {
         'x-annotator-auth-token': request.META['HTTP_X_ANNOTATOR_AUTH_TOKEN']
     }
+    
+    # Override the auth token for ATG when the user is a course administrator,
+    # so they can query against private annotations that have granted permission to the admin group.
+    if settings.ORGANIZATION == "ATG" and session_is_staff:
+        headers['x-annotator-auth-token'] = retrieve_token(
+            annotation_database.ADMIN_GROUP_ID,
+            assignment.annotation_database_apikey,
+            assignment.annotation_database_secret_token
+        )
 
     response = requests.post(database_url, headers=headers, params=url_values)
-    return HttpResponse(response)
+    return HttpResponse(response.content, status=response.status_code, content_type=response.headers['content-type'])
 
 
 @csrf_exempt
@@ -493,6 +504,9 @@ def annotation_database_create(request):
     request_object_id = str(json_body['uri'])
     request_context_id = json_body['contextId']
     request_user_id = json_body['user']['id']
+    
+    if settings.ORGANIZATION == "ATG":
+        annotation_database.update_read_permissions(json_body)
 
     debug_printer("%s: %s" % (session_user_id, request_user_id))
     debug_printer("%s: %s" % (session_collection_id, request_collection_id))
@@ -534,7 +548,7 @@ def annotation_database_create(request):
     except:
         debug_printer("is_graded was not found in the session")
 
-    return HttpResponse(response)
+    return HttpResponse(response.content, status=response.status_code, content_type=response.headers['content-type'])
 
 
 @csrf_exempt
@@ -621,20 +635,3 @@ def annotation_database_update(request, annotation_id):
 
     return HttpResponse(response)
 
-
-def get_admin_ids():
-    """
-        Returns a set of the user ids of all users with an admin role
-    """
-    admins = []
-    admin_ids = set()
-
-    # Get users with an admin role
-    for role in settings.ADMIN_ROLES:
-        admins += list(LTIProfile.objects.filter(roles=role))
-
-    # Add their ids to admin_ids
-    for admin in admins:
-        admin_ids.add(admin.get_id())
-
-    return admin_ids


### PR DESCRIPTION
This PR enables the ability for users to create public *or* private annotations in *ATG*'s instance of the tool.

**Goals**:
The goal of this PR is to 1) satisfy our client's need for private annotations 2) implement that using CATCH-level permission checking and 3) implement it in such a way that the functionality is not enabled for *HX* and does not impact *HX*.

**Dependencies**:
This PR depends on Catch v0.5.12 which incorporates permission checking. When a request is made to the CATCH database, CATCH compares the given user ID against the *read* permission of each annotation to ensure that the user has permission.

**Description**:
- Uses `settings.ORGANIZATION` to selectively enable this functionality for ATG.
- Enables the "View Permissions" UI option in annotator so the user can make an annotation private.
- Updates the read permissions whenever an annotation is created so that the course admin group ID is included in the permissions. So  `permissions.read = [user_id]` becomes `[user_id, "__admin__"]`.
- Ensures that replies to annotations are viewable by the annotation author, because enabling "View Permissions" in annotator enables this option for both annotations and replies, which can be confusing for the latter.
- Searches the CATCH with the admin group ID (i.e. `user_id = "__admin__"`) when the authenticated user is a course admin, so that private annotations are retrieved along with public annotations.