### PR TITLE
Manifest static files

### DIFF
--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -109,6 +109,7 @@ class CookielessSessionMiddleware(object):
 
         request.session = self.SessionStore(session_key)
         if not request.session.exists(request.session.session_key):
+            logger.debug("Created new session")
             request.session.create()
 
         # Mitigate security risks by ensuring the requesting user's IP matches the logged IP

--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -1,1 +1,3 @@
 from .base import *
+
+STATICFILES_STORAGE = 'annotationsx.staticfiles.MixedManifestStaticFilesStorage'

--- a/annotationsx/staticfiles.py
+++ b/annotationsx/staticfiles.py
@@ -1,0 +1,54 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from collections import OrderedDict
+import logging
+
+logger = logging.getLogger(__name__)
+
+class MixedManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    '''
+    This subclasses ManifestStaticFilesStorage to make it possible for the static asset manifest
+    to have a "mix" of files that have been hashed, and files that have not.
+
+    Example:
+
+    {
+        "paths": {
+            "AController.js": "AController.73751240244b.js",
+            "admin/css/base.css": "admin/css/base.css"
+        }
+    }
+
+    The problem this solves is when vendor CSS contains url() references to images or other static assets that were
+    not included in the build/distribution, and causes the post processor to fail. An example is mirador-combined.css,
+    which includes jqueryui as part of the distribution, but refers to image assets that were not included with mirador.
+    This issue causes the ManifestStaticFilesStorage post processor to fail.
+    '''
+    def post_process(self, paths, dry_run=False, **options):
+        hashed_files = OrderedDict()
+
+        # We can be reasonably confident that JS files can be hashed without any problem because we're not trying to
+        # change references inside the files themselves. This is not the case with CSS.
+        paths_to_process, paths_to_skip = dict(), dict()
+        for path in paths:
+            if path.endswith(".js"):
+                paths_to_process[path] = paths[path]
+            else:
+                paths_to_skip[path] = paths[path]
+
+        result = []
+
+        # Skip the hashing process on these paths, so the filename won't change to point to a hashed filename
+        for path in paths_to_skip:
+            processed = False
+            hashed_files[path] = path
+            result.append((path, path, processed))
+
+        # Run the hashing process on the paths we want to process
+        all_post_processed = super(ManifestStaticFilesStorage, self).post_process(paths_to_process, dry_run, **options)
+        for post_processed in all_post_processed:
+            result.append(post_processed)
+
+        self.hashed_files.update(hashed_files)
+        self.save_manifest()
+
+        return result

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -120,7 +120,6 @@
                     showPublicPrivateSelectors: true,
                     showMediaSelector: false,
                     flags: false,
-                    imageRootUrl: "{% static "vendors/catch/img"%}",
                     instructors: {{ assignment.course.course_admins| list_of_ids | safe}},
                     default_tab: "{{ assignment.default_tab }}",
                     show_instructor_tab: "{{assignment.include_instructor_tab}}",


### PR DESCRIPTION
Configured [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/1.7/ref/contrib/staticfiles/#manifeststaticfilesstorage) to ensure clients are receiving the latest static files. 

Due to issues with vendor CSS files referencing non-existent URLs, I customized it so that only JS files have their file names hashed. This solves the immediate issue with regard to application-specific JS that changes more frequently than vendor JS or CSS. Ideally, we should be able to resolve the issues with the vendor CSS so we can use standard `ManifestStaticFilesStorage` from django.

The biggest issue seems to be with `mirador-combined.css`, which has references to various *jqueryui* images that don't appear to exist on the filesystem, or in the mirador distribution for that matter.