### PR TITLE
Fixes issue with launch invalidation

### DIFF
--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -262,6 +262,7 @@ class MultiLTILaunchMiddleware(object):
         max_launches = getattr(settings, 'LTI_MAX_LAUNCHES', 10)
         self.logger.info("LTI launches in session: %s [max=%s]" % (lti_launches.keys(), max_launches))
         if len(lti_launches.keys()) >= max_launches:
+            self.logger.info("Invalidating oldest LTI launch (FIFO)")
             invalidated_launch = lti_launches.popitem(last=False)
             self.logger.info("LTI launch invalidated: %s", json.dumps(invalidated_launch, indent=4))
 

--- a/annotationsx/serializers.py
+++ b/annotationsx/serializers.py
@@ -1,0 +1,12 @@
+from collections import OrderedDict
+import json
+
+class JsonOrderedDictSerializer(object):
+    """
+    Simple wrapper around JSON serializer that decodes dicts as ordered dicts.
+    """
+    def dumps(self, obj):
+        return json.dumps(obj, separators=(',', ':')).encode('latin-1')
+
+    def loads(self, data):
+        return json.loads(data.decode('latin-1'), object_pairs_hook=OrderedDict)

--- a/annotationsx/settings/base.py
+++ b/annotationsx/settings/base.py
@@ -245,6 +245,11 @@ if ANNOTATION_HTTPS_ONLY:
     SESSION_COOKIE_SECURE = True
     SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
+# Instead of using the default JSON serializer, we need to modify it slightly so that
+# session dicts stored in JSON are de-serialized with their order preserved. This functionality
+# is used in particular by the MultiLTILaunchMiddleware.
+SESSION_SERIALIZER = 'annotationsx.serializers.JsonOrderedDictSerializer'
+
 # Organization-specific configuration
 # Try to minimize this as much as possible in favor of configuration
 if ORGANIZATION == "ATG":


### PR DESCRIPTION
This PR fixes a bug that occurs when a user has launched the tool more than 10 times. The 11th time the user launches the tool within a single browser session, they get an HTTP 500 error.

The issue is that the session dictionary maintains at most 10 launches, and any subsequent launch is supposed to take the place of the oldest one (FIFO). The launch dictionary is maintained as an `OrderedDict`, but the problem is that when `lti_launches.popitem(last=False)` is called, the following error is raised: `TypeError: popitem() takes no keyword arguments`. 

The problem is that Django deserializes the JSON session data using the standard `json` module, which converts ordered pairs into standard dicts. To deserialize into OrderedDicts, we have to create a custom deserializer that uses the [object_pairs_hook](https://docs.python.org/2.7/library/json.html#encoders-and-decoders) when decoding JSON. This should resolve the issue.

Note: this app is using database-backed sessions, so the session data is just serialized as JSON to the db.
 
@Chris-Thornton-Harvard Can you take a look and sanity check this for me?