### PR TITLE
Use reverse

### DIFF
--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -208,13 +208,10 @@ def launch_lti(request):
                 userfound.delete()
             except:
                 logger.info("Not waiting to be added as admin")
-        logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using TYLOR")
-        # ur = reverse('hx_lti_initializer:access_annotation_target')
-        # logger.debug('%s' % ur)
-        url = reverse('hx_lti_initializer:access_annotation_target', args=[course_id,assignment_id,object_id]) + '?resource_link_id=%s' % resource_link_id
-        logger.info("TYLOR: %s" % url)
+        logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using UI")
+        url = reverse('hx_lti_initializer:access_annotation_target', args=[course_id,assignment_id,object_id])
+        url += '?resource_link_id=%s' % resource_link_id
         return redirect(url)
-        # return access_annotation_target(request, course_id, assignment_id, object_id)
     except AnnotationTargetDoesNotExist as e:
         logger.warning('Could not access annotation target using resource config.')
         logger.info('Deleting resource config because it is invalid.')
@@ -252,15 +249,9 @@ def launch_lti(request):
                 return redirect(url)
             else:
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
-                url = reverse(
-                    'hx_lti_initializer:access_annotation_target',
-                    course_id=course_id,
-                    assignment_id=assignment_id,
-                    object_id=object_id,
-                    ) + '?resource_link_id=%s' % resource_link_id
-                logger.info("TYLOR: %s" % url)
+                url = reverse('hx_lti_initializer:access_annotation_target', args=[course_id,assignment_id,object_id])
+                url += '?resource_link_id=%s' % resource_link_id
                 return redirect(url)
-                # return access_annotation_target(request, course_id, assignment_id, object_id)
         except:
             logger.debug("DEBUG - User wants the index")
 

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -244,11 +244,10 @@ def launch_lti(request):
                     userfound.delete()
                 except:
                     logger.info("Not waiting to be added as admin")
-                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
                 url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
                 return redirect(url)
             else:
-                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
+                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object")
                 url = reverse('hx_lti_initializer:access_annotation_target', args=[course_id,assignment_id,object_id])
                 url += '?resource_link_id=%s' % resource_link_id
                 return redirect(url)

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -209,14 +209,9 @@ def launch_lti(request):
             except:
                 logger.info("Not waiting to be added as admin")
         logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using TYLOR")
-        ur = reverse('hx_lti_initializer:access_annotation_target')
-        logger.debug('%s' % ur)
-        url = reverse(
-            'hx_lti_initializer:access_annotation_target',
-            course_id=course_id,
-            assignment_id=assignment_id,
-            object_id=object_id,
-            ) + '?resource_link_id=%s' % resource_link_id
+        # ur = reverse('hx_lti_initializer:access_annotation_target')
+        # logger.debug('%s' % ur)
+        url = reverse('hx_lti_initializer:access_annotation_target', args=[course_id,assignment_id,object_id]) + '?resource_link_id=%s' % resource_link_id
         logger.info("TYLOR: %s" % url)
         return redirect(url)
         # return access_annotation_target(request, course_id, assignment_id, object_id)

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -209,7 +209,14 @@ def launch_lti(request):
             except:
                 logger.info("Not waiting to be added as admin")
         logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using UI")
-        return access_annotation_target(request, course_id, assignment_id, object_id)
+        url = reverse(
+            'hx_lti_initializer:access_annotation_target',
+            course_id=course_id,
+            assignment_id=assignment_id,
+            object_id=object_id,
+            ) + '?resource_link_id=%s' % resource_link_id
+        return redirect(url)
+        # return access_annotation_target(request, course_id, assignment_id, object_id)
     except AnnotationTargetDoesNotExist as e:
         logger.warning('Could not access annotation target using resource config.')
         logger.info('Deleting resource config because it is invalid.')
@@ -246,7 +253,14 @@ def launch_lti(request):
                 return redirect(url)
             else:
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object")
-                return access_annotation_target(request, course_id, assignment_id, object_id)
+                url = reverse(
+                    'hx_lti_initializer:access_annotation_target',
+                    course_id=course_id,
+                    assignment_id=assignment_id,
+                    object_id=object_id,
+                    ) + '?resource_link_id=%s' % resource_link_id
+                return redirect(url)
+                # return access_annotation_target(request, course_id, assignment_id, object_id)
         except:
             logger.debug("DEBUG - User wants the index")
 

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -209,7 +209,8 @@ def launch_lti(request):
             except:
                 logger.info("Not waiting to be added as admin")
         logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using TYLOR")
-        
+        ur = reverse('hx_lti_initializer:access_annotation_target')
+        logger.debug('%s' % ur)
         url = reverse(
             'hx_lti_initializer:access_annotation_target',
             course_id=course_id,
@@ -252,16 +253,8 @@ def launch_lti(request):
                 except:
                     logger.info("Not waiting to be added as admin")
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
-                url = reverse(
-                    'hx_lti_initializer:access_annotation_target',
-                    course_id=course_id,
-                    assignment_id=assignment_id,
-                    object_id=object_id,
-                    ) + '?resource_link_id=%s' % resource_link_id
-                logger.info("TYLOR: %s" % url)
+                url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
                 return redirect(url)
-                # url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
-                # return redirect(url)
             else:
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
                 url = reverse(

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -250,8 +250,17 @@ def launch_lti(request):
                     userfound.delete()
                 except:
                     logger.info("Not waiting to be added as admin")
-                url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
+                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
+                url = reverse(
+                    'hx_lti_initializer:access_annotation_target',
+                    course_id=course_id,
+                    assignment_id=assignment_id,
+                    object_id=object_id,
+                    ) + '?resource_link_id=%s' % resource_link_id
+                logger.info("TYLOR: %s" % url)
                 return redirect(url)
+                # url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
+                # return redirect(url)
             else:
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
                 url = reverse(

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -215,7 +215,7 @@ def launch_lti(request):
             assignment_id=assignment_id,
             object_id=object_id,
             ) + '?resource_link_id=%s' % resource_link_id
-        raise Exception(url)
+        logger.info("TYLOR: %s" % url)
         return redirect(url)
         # return access_annotation_target(request, course_id, assignment_id, object_id)
     except AnnotationTargetDoesNotExist as e:
@@ -260,7 +260,7 @@ def launch_lti(request):
                     assignment_id=assignment_id,
                     object_id=object_id,
                     ) + '?resource_link_id=%s' % resource_link_id
-                raise Exception(url)
+                logger.info("TYLOR: %s" % url)
                 return redirect(url)
                 # return access_annotation_target(request, course_id, assignment_id, object_id)
         except:

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -208,7 +208,8 @@ def launch_lti(request):
                 userfound.delete()
             except:
                 logger.info("Not waiting to be added as admin")
-        logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using UI")
+        logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using TYLOR")
+        
         url = reverse(
             'hx_lti_initializer:access_annotation_target',
             course_id=course_id,

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -253,7 +253,7 @@ def launch_lti(request):
                 url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % resource_link_id
                 return redirect(url)
             else:
-                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object")
+                logger.debug("DEBUG - User wants to go directly to annotations for a specific target object TYLOR")
                 url = reverse(
                     'hx_lti_initializer:access_annotation_target',
                     course_id=course_id,

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -215,6 +215,7 @@ def launch_lti(request):
             assignment_id=assignment_id,
             object_id=object_id,
             ) + '?resource_link_id=%s' % resource_link_id
+        raise Exception(url)
         return redirect(url)
         # return access_annotation_target(request, course_id, assignment_id, object_id)
     except AnnotationTargetDoesNotExist as e:
@@ -259,6 +260,7 @@ def launch_lti(request):
                     assignment_id=assignment_id,
                     object_id=object_id,
                     ) + '?resource_link_id=%s' % resource_link_id
+                raise Exception(url)
                 return redirect(url)
                 # return access_annotation_target(request, course_id, assignment_id, object_id)
         except:


### PR DESCRIPTION
This pull request should resolve the resource_link_id not present bug by:
- When navigating to `access_annotation_target` view, construct url using reverse and passing arguments
- When url is constructed, concatenate resource_link_id to url
- redirect to url