### PR TITLE
IMM integration

### DIFF
--- a/annotationsx/requirements/base.txt
+++ b/annotationsx/requirements/base.txt
@@ -12,7 +12,7 @@ httplib2==0.12.1
 idna==2.8
 lti==0.9.3
 lxml==4.3.3
-git+https://github.com/i-kiwamu/python3-oauth2
+git+https://github.com/i-kiwamu/python3-oauth2#egg=oauth2
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 python-dateutil==2.8.0

--- a/annotationsx/settings/base.py
+++ b/annotationsx/settings/base.py
@@ -227,6 +227,11 @@ LOGGING = {
             'handlers': ['default', 'console'],
             'propagate': False,
         },
+        'image_store.backends': {
+            'level': _DEFAULT_LOG_LEVEL,
+            'handlers': ['default', 'console'],
+            'propagate': False,
+        },
     },
 }
 
@@ -280,6 +285,8 @@ ANNOTATION_HTTPS_ONLY = literal_eval(os.environ.get("HTTPS_ONLY", str(SECURE_SET
 ANNOTATION_LOGGER_URL = os.environ.get('ANNOTATION_LOGGER_URL', SECURE_SETTINGS.get("annotation_logger_url", ""))
 ANNOTATION_STORE = os.environ.get('ANNOTATION_STORE', SECURE_SETTINGS.get("annotation_store", {}))
 ACCESSIBILITY = literal_eval(os.environ.get('ACCESSIBILITY', str(SECURE_SETTINGS.get('accessibility', True))))
+IMAGE_STORE_BACKEND = os.environ.get('IMAGE_STORE_BACKEND', str(SECURE_SETTINGS.get('image_store_backend', '')))
+IMAGE_STORE_BACKEND_CONFIG = os.environ.get('IMAGE_STORE_BACKEND_CONFIG', SECURE_SETTINGS.get('image_store_backend_config', ''))
 
 SESSION_COOKIE_SAMESITE = None
 CSRF_COOKIE_SAMESITE = None

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -136,7 +136,7 @@ class IMMImageStoreBackend(ImageStoreBackend):
                 course = courses[0]
             else:
                 raise ImageStoreBackendException("Multiple courses found {num}".format(num=len(courses)))
-        elif r.status_code == 404:``
+        elif r.status_code == 404:
             course = self._create_course()
         else:
             raise ImageStoreBackendException("Find course error: {status_code}".format(status_code=r.status_code))

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -1,0 +1,215 @@
+import requests
+import json
+import html
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ImageStoreBackendException(Exception):
+    pass
+
+class ImageStoreBackend:
+    '''
+    Image storage backend.
+    '''
+    def __init__(self, config=None, lti_params=None):
+        ''' Initialize backend with config and LTI parameters as required. '''
+        pass
+
+    def store(self, uploaded_files, title):
+        ''' Returns URL to a IIIF manifest containing the images. '''
+        pass
+
+
+class IMMImageStoreBackend(ImageStoreBackend):
+    '''
+    Collaborates with the Image Media Manager (IMM) service to store images
+    and generate IIIF manifests.
+    
+    See also: https://github.com/harvard-atg/media_management_api
+
+    Notes:
+    - IMM requires client credentials (client key and secret) to authenticate and obtain a 
+      temporary access token for subsequent requests.
+    - Requires LTI context_id and tool_consumer_instance_guid to identify the course library.
+    - Additional LTI context/course attributes are provided when creating a new course library.
+    - A collection is associated with a manifest, so as soon as a collection is created, a manifest
+      URL can be obtained and it will be generated on the fly.
+    '''
+    def __init__(self, config=None, lti_params=None):
+        super().__init__(config, lti_params)
+
+        # configuration for API
+        self.client_id = config['client_id']
+        self.client_secret = config['client_secret']
+        self.base_url = config['base_url']
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        # course-specific parameters
+        self.user_id = lti_params['lis_person_sourcedid']
+        self.course_attrs = {
+            "lti_context_id": lti_params['context_id'],
+            "lti_tool_consumer_instance_guid": lti_params['tool_consumer_instance_guid'],
+            "lti_tool_consumer_instance_name": lti_params['tool_consumer_instance_name'],
+            "lti_context_title": lti_params['context_title'],
+            "lti_context_label": lti_params['context_label'],
+            "title": html.unescape(lti_params['context_title']),
+            "sis_course_id": lti_params['lis_course_offering_sourcedid'],
+            "canvas_course_id": lti_params['custom_canvas_course_id'],
+        }
+
+    def store(self, uploaded_files, title):
+        ''' Returns URL to a IIIF manifest containing the images. '''
+        manifest_url = None
+        try:
+            # authenticate 
+            access_token = self._authenticate()
+            self.headers['Authorization'] = 'Token {access_token}'.format(access_token=access_token)
+
+            # create course space if not exists for storing images
+            course = self._find_or_create_course()
+
+            # upload image to the course space
+            course_images = self._upload_images(course['id'], uploaded_files)
+            course_image_ids = [image['id'] for image in course_images]
+            
+            # create a collection and add images to it
+            collection = self._create_collection(course['id'], title)
+            self._add_to_collection(collection['id'], course_image_ids)
+            
+            # get IIIF manifest URL for collection
+            collection = self._get_collection(collection['id'])
+            manifest_url = collection.get('iiif_manifest', {}).get('url')
+
+        except ImageStoreBackendException as e:
+            logger.exception("Image store backend error: %s" % str(e))
+            raise e
+
+        return manifest_url
+
+    def _authenticate(self):
+        ''' 
+        Authenticates with API using client credentials (key/secret).
+        Obtains temporary access token for subsequent API requests.
+        '''
+        url = "%s/auth/obtain-token" % self.base_url
+        post_data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "user_id": self.user_id,
+        }
+        r = requests.post(url, headers=self.headers, data=json.dumps(post_data))
+        logger.debug("API POST {url} data:{post_data} status:{status_code} text:{text}".format(url=url, post_data=post_data, status_code=r.status_code, text=r.text))
+        
+        access_token = None
+        if r.status_code == 200:
+            data = r.json()
+            access_token = data.get('access_token', None)
+            if not access_token:
+                raise ImageStoreBackendException("Authenticated successfully, but access token absent from response")
+        else: 
+            raise ImageStoreBackendException("Authentication failed: {status_code}".format(status_code=r.status_code))
+        return access_token
+    
+    def _find_or_create_course(self):
+        '''
+        Find associated course space for images using Canvas/LTI identifiers.
+        If no course space exists, create one.
+        '''
+        url = "%s/courses" % self.base_url
+        search_params = {
+            "lti_context_id": self.course_attrs["lti_context_id"],
+            "lti_tool_consumer_instance_guid": self.course_attrs["lti_tool_consumer_instance_guid"]
+        }
+        r = requests.get(url, headers=self.headers, params=search_params)
+        logger.debug("API GET {url} params:{params} status:{status_code} text:{text}".format(url=url, params=search_params, status_code=r.status_code, text=r.text))
+
+        course = None
+        if r.status_code == 200:
+            courses = r.json()
+            if len(courses) == 0:
+                course = self._create_course()
+            else:
+                course = courses[0]
+        elif r.status_code == 404:
+            course = self._create_course()
+        else:
+            raise ImageStoreBackendException("Find course error: {status_code}".format(status_code=r.status_code))
+        return course
+
+    def _create_course(self):
+        '''
+        Create a new course space for images.
+        '''
+        url = "%s/courses" % self.base_url
+        post_data = self.course_attrs
+        r = requests.post(url, headers=self.headers, data=json.dumps(post_data))
+        logger.debug("API POST {url} data:{data} status:{status_code} text:{text}".format(url=url, data=post_data, status_code=r.status_code, text=r.text))
+
+        if r.status_code not in (200, 201):
+            raise ImageStoreBackendException("Create course error: {status_code}".format(status_code=r.status_code))
+        return r.json()
+
+    def _upload_images(self, course_id, uploaded_files):
+        '''
+        Upload images to course space.
+        '''
+        url = "%s/courses/%s/images" % (self.base_url, course_id)
+        post_files = []
+        for uploaded_file in uploaded_files:
+            file_tuple = (uploaded_file.name, uploaded_file.read(), uploaded_file.content_type)
+            post_files.append(('file', file_tuple)) # the field name must be "files" 
+
+        post_headers = {'Authorization': self.headers['Authorization']}
+        r = requests.post(url, headers=post_headers, data={'title':'Untitled'}, files=post_files)
+        logger.debug("API POST {url} status:{status_code} text:{text}".format(url=url, status_code=r.status_code, text=r.text))
+
+        if r.status_code not in (200, 201):
+            raise ImageStoreBackendException("Upload image error: {status_code}".format(status_code=r.status_code))
+        return r.json()
+
+    def _create_collection(self, course_id, title="Untitled Collection", description="Image Annotation"):
+        '''
+        Create a new collection.
+        '''
+        url = "%s/courses/%s/collections" % (self.base_url, course_id)
+        post_data = {"title": title, "description": description}
+        r = requests.post(url, headers=self.headers, data=json.dumps(post_data))
+        logger.debug("API POST {url} data:{data} status:{status_code} text:{text}".format(url=url, data=post_data, status_code=r.status_code, text=r.text))
+
+        if r.status_code not in (200, 201):
+            raise ImageStoreBackendException("Create collection error: {status_code}".format(status_code=r.status_code))
+        return r.json()
+
+    def _get_collection(self, collection_id):
+        '''
+        Retrieve collection details.
+        '''
+        url = "%s/collections/%s" % (self.base_url, collection_id)
+        r = requests.get(url, headers=self.headers)
+        logger.debug("API GET {url} status:{status_code} text:{text}".format(url=url, status_code=r.status_code, text=r.text))
+
+        if r.status_code == 200:
+            collection = r.json()
+        elif r.status_code == 404:
+            collection = False
+        else:
+            raise ImageStoreBackendException("Get collection error: {status_code}".format(status_code=r.status_code))
+        return collection
+
+    def _add_to_collection(self, collection_id, image_ids):
+        '''
+        Add images from course space to a specific collection so that we can obtain a IIIF manifest.
+        '''
+        url = "%s/collections/%s/images" % (self.base_url, collection_id)
+        post_data = [dict(course_image_id=image_id) for image_id in image_ids]
+        r = requests.post(url, headers=self.headers, data=json.dumps(post_data))
+        logger.debug("API POST {url} data:{data} status:{status_code} text:{text}".format(url=url, data=post_data, status_code=r.status_code, text=r.text))
+
+        if r.status_code not in (200, 201):
+            raise ImageStoreBackendException("Add images to collection error: {status_code}".format(status_code=r.status_code))
+        return r.json()
+    

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -132,9 +132,11 @@ class IMMImageStoreBackend(ImageStoreBackend):
             courses = r.json()
             if len(courses) == 0:
                 course = self._create_course()
-            else:
+            elif len(courses) == 1:
                 course = courses[0]
-        elif r.status_code == 404:
+            else:
+                raise ImageStoreBackendException("Multiple courses found {num}".format(num=len(courses)))
+        elif r.status_code == 404:``
             course = self._create_course()
         else:
             raise ImageStoreBackendException("Find course error: {status_code}".format(status_code=r.status_code))

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -87,6 +87,9 @@ class IMMImageStoreBackend(ImageStoreBackend):
         except ImageStoreBackendException as e:
             logger.exception("Image store backend error: %s" % str(e))
             raise e
+        except requests.exceptions.RequestException as e:
+            logger.exception("Image store request exception: %s" % str(e))
+            raise ImageStoreBackendException('Image store HTTP connection error: %s' % str(e))
 
         return manifest_url
 

--- a/image_store/tests.py
+++ b/image_store/tests.py
@@ -1,0 +1,223 @@
+import unittest
+import json
+import html
+from unittest.mock import Mock, patch
+
+from . import backends 
+
+ImageStoreBackend = backends.ImageStoreBackend
+IMMImageStoreBackend = backends.IMMImageStoreBackend
+
+class TestImageStoreBackend(unittest.TestCase):
+    def test_backend_has_required_methods(self):
+        backend = ImageStoreBackend()
+        self.assertTrue(hasattr(backend, 'store'))
+
+
+class TestIMMImageStoreBackend(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'base_url': 'http://media-management-api.localhost/api', 
+            'client_id': 'my-client-id', 
+            'client_secret': 'my-secret', 
+        }
+        self.user_id = 'aaaabbbb'
+        self.lti_params = {
+            'tool_consumer_instance_guid': '7db438071375c02373713c12c73869ff2f470b68.harvard.instructure.com', 
+            'tool_consumer_instance_name': 'Harvard University',
+            'context_id': '9a8b2d3fa51ef413d19e480fb6c2ab091b7866a9',
+            'context_label': 'demo-foo',
+            'context_title': 'Foo&#39;s Demo Course',
+            'lis_course_offering_sourcedid': 'demo-foo', 
+            'lis_person_sourcedid': self.user_id, 
+            'custom_canvas_course_id': '11223344',
+        }
+
+    def test_constructor(self):
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+
+        # check configuration
+        self.assertEqual(self.config['base_url'], backend.base_url)
+        self.assertEqual(self.config['client_id'], backend.client_id)
+        self.assertEqual(self.config['client_secret'], backend.client_secret)
+
+        # check lti params
+        self.assertEqual(self.lti_params['lis_person_sourcedid'], backend.user_id)
+        self.assertTrue(hasattr(backend, 'course_attrs'))
+        self.assertEqual(self.lti_params['tool_consumer_instance_guid'], backend.course_attrs['lti_tool_consumer_instance_guid'])
+        self.assertEqual(self.lti_params['tool_consumer_instance_name'], backend.course_attrs['lti_tool_consumer_instance_name'])
+        self.assertEqual(self.lti_params['context_id'], backend.course_attrs['lti_context_id'])
+        self.assertEqual(self.lti_params['context_label'], backend.course_attrs['lti_context_label'])
+        self.assertEqual(self.lti_params['context_title'], backend.course_attrs['lti_context_title'])
+        self.assertEqual(self.lti_params['lis_course_offering_sourcedid'], backend.course_attrs['sis_course_id'])
+        self.assertEqual(self.lti_params['custom_canvas_course_id'], backend.course_attrs['canvas_course_id'])
+
+        # check initial headers
+        self.assertTrue(hasattr(backend, 'headers'))
+        expected_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        self.assertEqual(expected_headers, backend.headers)
+
+    @patch('image_store.backends.requests.post')
+    def test_authenticate(self, mock_post):
+        request_url = "%s/auth/obtain-token" % self.config['base_url']
+        request_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        request_data = {
+            "client_id": self.config['client_id'],
+            "client_secret": self.config['client_secret'],
+            "user_id": self.user_id,
+        }
+        response_data = {
+            "course_id": None,
+            "user_id": self.user_id,
+            "access_token": 'ABC-123423asdfascxwQRW-AAAA',
+            "expires": "2030-01-03 15:35:49",
+            "course_permission": None
+        }
+        mock_post.return_value = Mock(ok=True, status_code=200)
+        mock_post.return_value.json.return_value = response_data
+        
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        actual_access_token = backend._authenticate()
+
+        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
+        self.assertEqual(response_data["access_token"], actual_access_token)
+        
+    @patch('image_store.backends.requests.post')
+    def test_create_course(self, mock_post):
+        request_url = "%s/courses" % self.config['base_url']
+        request_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": "Token Fake123",
+        }
+        request_data = {
+            "lti_context_id": self.lti_params['context_id'],
+            "lti_tool_consumer_instance_guid": self.lti_params['tool_consumer_instance_guid'],
+            "lti_tool_consumer_instance_name": self.lti_params['tool_consumer_instance_name'],
+            "lti_context_title": self.lti_params['context_title'],
+            "lti_context_label": self.lti_params['context_label'],
+            "title": html.unescape(self.lti_params['context_title']),
+            "sis_course_id": self.lti_params['lis_course_offering_sourcedid'],
+            "canvas_course_id": self.lti_params['custom_canvas_course_id'],
+        }
+        response_data = {
+            "id": 101,
+            "created": "2020-01-16T20:34:42.887005Z",
+            "updated": "2020-01-16T20:34:42.887032Z",
+        }
+        response_data.update(request_data)
+
+        mock_post.return_value = Mock(ok=True, status_code=201)
+        mock_post.return_value.json.return_value = response_data
+
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        backend.headers = request_headers
+        actual_data = backend._create_course()
+
+        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
+        self.assertEqual(response_data, actual_data)
+
+    @patch('image_store.backends.requests.post')
+    def test_create_collection(self, mock_post):
+        course_id = 123
+        title = "Image Annotation"
+        request_url = "%s/courses/%s/collections" % (self.config['base_url'], course_id)
+        request_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": "Token Fake123",
+        }
+        request_data = {
+            "title": title,
+            "description": "Image Annotation"
+        }
+        response_data = {
+            "id": 901,
+            "created": "2020-01-16T20:34:42.887005Z",
+            "updated": "2020-01-16T20:34:42.887005Z",
+            "title": request_data['title'],
+            "description": request_data['description'],
+            "course_id": course_id,
+            "course_image_ids": [],
+            "iiif_manifest": {
+                "source": "images",
+                "canvas_id": "",
+                "url": "%s/iiif/manifest/641" % self.config['base_url']
+            },
+        }
+
+        mock_post.return_value = Mock(ok=True, status_code=201)
+        mock_post.return_value.json.return_value = response_data
+
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        backend.headers = request_headers
+        actual_data = backend._create_collection(course_id, title)
+
+        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
+        self.assertEqual(response_data, actual_data)
+
+    @patch('image_store.backends.requests.get')
+    def test_get_collection(self, mock_get):
+        collection_id = 555
+        request_url = "%s/collections/%s" % (self.config['base_url'], collection_id)
+        request_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": "Token Fake123",
+        }
+        response_data = {
+            "id": collection_id,
+            "created": "2020-01-16T20:34:42.887005Z",
+            "updated": "2020-01-16T20:34:42.887005Z",
+            "title": "Test Collection",
+            "description": "",
+            "course_id": 123,
+            "course_image_ids": [],
+            "iiif_manifest": {
+                "source": "images",
+                "canvas_id": "",
+                "url": "%s/iiif/manifest/%s" % (self.config['base_url'], collection_id)
+            },
+        }
+
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = response_data
+
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        backend.headers = request_headers
+        actual_data = backend._get_collection(collection_id)
+
+        mock_get.assert_called_with(request_url, headers=request_headers)
+        self.assertEqual(response_data, actual_data)
+
+    @patch('image_store.backends.requests.post')
+    def test_add_to_collection(self, mock_post):
+        collection_id = 555
+        image_ids = [100,101,102]
+        request_url = "%s/collections/%s/images" % (self.config['base_url'], collection_id)
+        request_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": "Token Fake123",
+        }
+        request_data = [dict(course_image_id=image_id) for image_id in image_ids]
+        response_data = [{
+            "id": idx,
+            "collection_id": collection_id,
+            "course_image_id": image_id,
+            } for idx, image_id in enumerate(image_ids)]
+        mock_post.return_value = Mock(ok=True, status_code=201)
+        mock_post.return_value.json.return_value = response_data
+
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        backend.headers = request_headers
+        actual_data = backend._add_to_collection(collection_id, image_ids)
+
+        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
+        self.assertEqual(response_data, actual_data)

--- a/target_object_database/forms.py
+++ b/target_object_database/forms.py
@@ -1,9 +1,17 @@
 from django import forms
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.forms import ValidationError
 from target_object_database.models import TargetObject
 from hx_lti_initializer.utils import debug_printer
 
+import image_store.backends
 
 class SourceForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop('request', None)
+        super(SourceForm, self).__init__(*args, **kwargs)
 
     def clean(self):
         super(SourceForm, self).clean()
@@ -16,8 +24,19 @@ class SourceForm(forms.ModelForm):
         except:
             pass
         if possible_to is not None and possible_to.target_type == "ig":
-            msg = "This image manifest already exists and is named %s" % possible_to
+            msg = "The image manifest already exists and is named %s (url: %s)" % (possible_to, possible_to.target_content)
             self.add_error('target_content', msg)
+
+    def save(self):
+        if self.files and settings.IMAGE_STORE_BACKEND:
+            try:
+                manifest_url = handle_file_upload(self.data, self.files, self.request.LTI['launch_params'])
+            except ValidationError as e:
+                self.add_error(None, str(e))
+                raise e
+            self.instance.target_content = manifest_url
+
+        return super(SourceForm, self).save()
 
     class Meta:
         model = TargetObject
@@ -30,3 +49,35 @@ class SourceForm(forms.ModelForm):
             'target_courses',
             'target_type'
         )
+
+
+def handle_file_upload(data, files, lti_params):
+    '''
+    Parameters:
+        data(dict): the request.POST dict-like object
+        files(dict): the request.FILES dict-like object
+        lti_params(dict): should be the initial LTI launch params stored in th session
+    
+    Returns:
+        str: the manifest URL
+    
+    Raises:
+        ValidationError: Error saving the image
+    '''
+    image_backend_class = getattr(image_store.backends, settings.IMAGE_STORE_BACKEND)
+    image_backend = image_backend_class(settings.IMAGE_STORE_BACKEND_CONFIG, lti_params)
+    
+    title = data.get('target_title', 'Untitled Target Object')
+    if 'target_file' not in files:
+        raise ValidationError("Error saving image. Missing 'target_file' field.")
+    uploaded_file = files['target_file']
+    
+    try:
+        manifest_url = image_backend.store([uploaded_file], title)
+    except image_store.backends.ImageStoreBackendException as e:
+        raise ValidationError("Error saving image. Details: %s" % e)
+
+    if not manifest_url:
+        raise ValidationError("Failed to get manifest after saving image (manifest required for annotation).")
+
+    return manifest_url

--- a/target_object_database/forms.py
+++ b/target_object_database/forms.py
@@ -90,12 +90,12 @@ def handle_file_upload(data, files, lti_params):
     Raises:
         ValidationError
     '''
-    image_backend_class = getattr(image_store.backends, settings.IMAGE_STORE_BACKEND)
-    image_backend = image_backend_class(settings.IMAGE_STORE_BACKEND_CONFIG, lti_params)
-    
-    title = data.get('target_title', 'Untitled Target Object')
+    title = "Annotation: %s" % data.get('target_title', 'Untitled Target Object')
     uploaded_file = files['target_file']
+
     try:
+        image_backend_class = getattr(image_store.backends, settings.IMAGE_STORE_BACKEND)
+        image_backend = image_backend_class(settings.IMAGE_STORE_BACKEND_CONFIG, lti_params)
         manifest_url = image_backend.store([uploaded_file], title)
     except image_store.backends.ImageStoreBackendException as e:
         raise ValidationError("Error uploading image. Details: %s" % e)

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -2,6 +2,20 @@
 {% load extra_options %}
 {% load staticfiles %}
 
+{% block css_file %}
+<style type="text/css">
+#id_image_upload_preview ol {
+	list-style-type: none;
+	margin-left: 0;
+	padding-left: 0;
+	padding-top: 10px;
+}
+#id_image_upload_preview img {
+	max-width: 75%;
+}
+</style>
+{% endblock %}
+
 {% block content %}
 {% load bootstrap3 %}
 {# bootstrap_css #}
@@ -133,7 +147,8 @@
                             jQuery('#id_target_content').before('<p id="content-error" style="color:red; font-size:10pt;">Not a valid manifest URL. Make sure it\'s only one URL and that it begins with "https".</p>');
                         }
                     });
-					jQuery('label[for="id_target_content"]').text('Mirador Manifests');
+					jQuery('label[for="id_target_content"]').text('Source Manifest');
+					jQuery('#id_image_store').show();
 				}
 			});
 			jQuery('#id_target_type').trigger('change');
@@ -149,13 +164,80 @@
 				}
 			}, 500);
 		});
+
+		// For handling image uploads to the image store backend (only if enabled)
+		$(document).ready(function() {
+			const fileTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+			const input = document.getElementById('id_image_upload');
+			const preview = document.getElementById('id_image_upload_preview');
+			//input.style.opacity = 0;
+
+			function validFileType(file) {
+				for(let i = 0; i < fileTypes.length; i++) {
+					if(file.type === fileTypes[i]) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			function returnFileSize(number) {
+				if(number < 1024) {
+					return number + 'bytes';
+				} else if(number >= 1024 && number < 1048576) {
+					return (number/1024).toFixed(1) + 'KB';
+				} else if(number >= 1048576) {
+					return (number/1048576).toFixed(1) + 'MB';
+				}
+			}
+
+			function updateImageDisplay() {
+				while(preview.firstChild) {
+					preview.removeChild(preview.firstChild);
+				}
+
+				const curFiles = input.files;
+				if(curFiles.length === 0) {
+					let para = document.createElement('p');
+					para.textContent = 'No files currently selected for upload';
+					preview.appendChild(para);
+				} else {
+					let list = document.createElement('ol');
+					preview.appendChild(list);
+					for(let i = 0; i < curFiles.length; i++) {
+						let listItem = document.createElement('li');
+						let para = document.createElement('p');
+						if(validFileType(curFiles[i])) {
+							para.textContent = 'File name ' + curFiles[i].name + ', file size ' + returnFileSize(curFiles[i].size) + '.';
+							let image = document.createElement('img');
+							image.src = window.URL.createObjectURL(curFiles[i]);
+							listItem.appendChild(image);
+							listItem.appendChild(para);
+						} else {
+							para.textContent = 'File name ' + curFiles[i].name + ': Not a valid file type. Update your selection.';
+							listItem.appendChild(para);
+						}
+						list.appendChild(listItem);
+					}
+				}
+			}
+
+			// Update image preview when file input changes
+			if(input) {
+				input.addEventListener('change', updateImageDisplay);
+			}
+		});
 	</script>
 
 	<h2>Edit Source Material</h2>
 
 	<div id='example-holder'><img id='example-image' class='ig'> <p>Be aware that any changes made below will affect all courses that use this source.</p></div>
 
-	<form method="POST" class="post-form">{% csrf_token %}
+	{% if form.non_field_errors %}
+		{{ form.non_field_errors }}
+	{% endif %}
+
+	<form method="POST" class="post-form" enctype="multipart/form-data">{% csrf_token %}
 		<div class="form-group">
 			<label for="id_target_type">Annotation Type</label> 
 			<select class="form-control selectpicker" data-live-search="false" id="id_target_type" name="target_type">
@@ -173,11 +255,25 @@
 			<label for="id_target_author">Source Author:</label> 
 			<input id="id_target_author" maxlength="255" name="target_author" class="form-control hx-textfield" type="text" value="{{ form.target_author.value }}">
 		</div>
+
+		{% if image_store_enabled %}
+		<div id="id_image_store" style="display:none;">
+			<div id="id_form_group_image_upload" class="form-group" style="padding: 10px 40px 10px 0px;">
+				<label for="id_image_upload">Source Image (PNG, JPG)</label>
+				<input type="file" id="id_image_upload" name="target_file" accept=".jpg, .jpeg, .png" multiple>
+				<div id="id_image_upload_preview">
+					<p>No files currently selected for upload. </p>
+				</div>
+			</div>
+		</div>
+		{% endif %}
+
 		<div class="form-group vdchange ig tx" style='width:84%;'>
 			<label for="id_target_content">Source Content:</label> 
             {{form.target_content.errors}}
 			<textarea id="id_target_content" name="target_content" class="form-control hx-textfield">{{ form.target_content.value | escape  }}</textarea>
 		</div>
+
 		<div class="form-group">
 			<label for="id_target_citation">Source Citation:</label> 
 			<textarea id="id_target_citation" name="target_citation" class="form-control hx-textfield">{{ form.target_citation.value | escape }}</textarea>

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -67,10 +67,28 @@
 		  });
 		  {% endif %}
 		  jQuery('form').on('click', '#source-save-button', function(event) {
-		  	jQuery(this).closest('form').submit();
+				var allow_submit = true;
+				var required_for_all_types = ['id_target_type', 'id_target_title'];
+				required_for_all_types.forEach(function(id) {
+					var el = document.getElementById(id);
+					if(!el.value) {
+						allow_submit = false;
+					}
+					markRequiredIfEmpty(el);
+				});
+				if(allow_submit) {
+					jQuery(this).closest('form').submit();
+				}
 		  });
 	});
-		
+
+	var markRequiredIfEmpty = function(el) {
+		if(el.value) {
+			$(el).css({'outline': 'none', 'outline-offset': 'none'})
+		} else {
+			$(el).css({'outline': 'red 2px solid', 'outline-offset': '5px'});
+		}
+	}
 
 	var createVideoFields = function() {
 		jQuery('.vdchange').before("<div class='form-group vd'>\
@@ -133,28 +151,18 @@
 					jQuery('.ig').show();
 					jQuery('#id_target_content').destroy();
 					jQuery('form').off('submit'); // fixes issue with summernote still having a "submit" event handler attached after destroy...
-                    jQuery('#id_target_content').blur( function() {
-                        var content = jQuery('#id_target_content').val();
-                        var expression = /https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
-                        var regex = new RegExp(expression);
-                        jQuery('#content-error').remove();
-                        if (content.match(regex) && content.match(regex).length === 1) {
-                            jQuery('#id_target_content').css('outline', 'none');
-                            jQuery('#id_target_content').css('outline-offset', 'none');
-                        } else {
-                            jQuery('#id_target_content').css('outline', 'red 2px solid');
-                            jQuery('#id_target_content').css('outline-offset', '5px');
-                            jQuery('#id_target_content').before('<p id="content-error" style="color:red; font-size:10pt;">Not a valid manifest URL. Make sure it\'s only one URL and that it begins with "https".</p>');
-                        }
-                    });
 					jQuery('label[for="id_target_content"]').text('Source Manifest');
 					jQuery('#id_image_store').show();
 				}
 			});
+
+			jQuery('#id_target_title').on('blur', function(e) {
+				this.value = this.value.trim();
+				markRequiredIfEmpty(this);
+			});
+
 			jQuery('#id_target_type').trigger('change');
-            jQuery('#id_target_content').focus(function(){console.log("targetabouttochange");}).blur( function(){
-                console.log("Targetchanged");
-            });
+			
 			setTimeout(function(){
 				if (window.navigator.platform === "Win32") {
 					jQuery('.bootstrap-select.form-control').addClass('win');
@@ -237,7 +245,7 @@
 		{{ form.non_field_errors }}
 	{% endif %}
 
-	<form method="POST" class="post-form" enctype="multipart/form-data">{% csrf_token %}
+	<form method="POST" id="id_target_form" class="post-form" enctype="multipart/form-data">{% csrf_token %}
 		<div class="form-group">
 			<label for="id_target_type">Annotation Type</label> 
 			<select class="form-control selectpicker" data-live-search="false" id="id_target_type" name="target_type">
@@ -248,11 +256,13 @@
 		</div>
 
 		<div class="form-group">
-			<label for="id_target_title">Source Title:</label> 
-			<input id="id_target_title" maxlength="255" name="target_title" class="form-control hx-textfield" type="text" value="{{ form.target_title.value }}">
+			<label for="id_target_title">Source Title:</label>
+			{{form.target_title.errors}}  
+			<input id="id_target_title" maxlength="255" name="target_title" class="form-control hx-textfield" type="text" value="{{ form.target_title.value | default_if_none:"" }}" required>
 		</div>
 		<div class="form-group tx">
 			<label for="id_target_author">Source Author:</label> 
+			{{form.target_author.errors}} 
 			<input id="id_target_author" maxlength="255" name="target_author" class="form-control hx-textfield" type="text" value="{{ form.target_author.value }}">
 		</div>
 
@@ -271,12 +281,13 @@
 		<div class="form-group vdchange ig tx" style='width:84%;'>
 			<label for="id_target_content">Source Content:</label> 
             {{form.target_content.errors}}
-			<textarea id="id_target_content" name="target_content" class="form-control hx-textfield">{{ form.target_content.value | escape  }}</textarea>
+			<textarea id="id_target_content" name="target_content" class="form-control hx-textfield">{{ form.target_content.value | default_if_none:"" | escape  }}</textarea>
 		</div>
 
 		<div class="form-group">
-			<label for="id_target_citation">Source Citation:</label> 
-			<textarea id="id_target_citation" name="target_citation" class="form-control hx-textfield">{{ form.target_citation.value | escape }}</textarea>
+			<label for="id_target_citation">Source Citation:</label>
+			{{form.target_citation.errors}} 
+			<textarea id="id_target_citation" name="target_citation" class="form-control hx-textfield">{{ form.target_citation.value | default_if_none:"" | escape }}</textarea>
 		</div>
 
 		<div class="form-group" style='display:none;'>

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from rest_framework import generics
 from hx_lti_initializer.utils import debug_printer
 
+
 def get_course_id(request):
 	return request.LTI['hx_lti_course_id']
 
@@ -99,11 +100,11 @@ def edit_source(request, id):
 
 def handlePopAdd(request, addForm, field):
     if request.method == "POST":
-        form = addForm(request.POST)
+        form = addForm(request.POST, request.FILES, request=request)
         if form.is_valid():
             try:
                 newObject = form.save()
-            except (ValidationError, error):
+            except ValidationError:
                 newObject = None
             if newObject:
                 return HttpResponse('<script type="text/javascript">opener.dismissAddAnotherPopup(window, "%s", "%s", "%s", "%s", "%s");</script>' % (escape(newObject._get_pk_val()), escape(newObject.target_title), escape(newObject.target_author), escape(newObject.target_created), escape(newObject.target_type)))  # noqa
@@ -117,6 +118,7 @@ def handlePopAdd(request, addForm, field):
         'course': get_course_id(request),
         'org': settings.ORGANIZATION,
         'is_instructor': request.LTI['is_staff'],
+        'image_store_enabled': bool(settings.IMAGE_STORE_BACKEND),
     }
     return render(
         request,
@@ -137,3 +139,4 @@ class SourceView(generics.ListAPIView):
     def get_queryset(self):
         object_id = self.kwargs['object_id']
         return TargetObject.objects.filter(pk=object_id)
+

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -53,7 +53,6 @@ def create_new_source(request):
             debug_printer(form.errors)
     else:
         form = SourceForm()
-        print("AAAAAHHHHHHHH")
     return render(
         request,
         'target_object_database/source_form.html',
@@ -104,7 +103,7 @@ def handlePopAdd(request, addForm, field):
         if form.is_valid():
             try:
                 newObject = form.save()
-            except ValidationError:
+            except ValidationError as e:
                 newObject = None
             if newObject:
                 return HttpResponse('<script type="text/javascript">opener.dismissAddAnotherPopup(window, "%s", "%s", "%s", "%s", "%s");</script>' % (escape(newObject._get_pk_val()), escape(newObject.target_title), escape(newObject.target_author), escape(newObject.target_created), escape(newObject.target_type)))  # noqa


### PR DESCRIPTION
Integrates IMM backend so that teaching staff can upload an image for annotation without having to provide a manifest URL explicitly. 

Functionality:
- Added `image_store.backends` to provide the image upload functionality. It's expected to be able to upload an image and return a manifest URL, as required by annotationsx.
- Added two configuration settings. If no backend is configured, then the option to upload an image will not appear to the user.
    1. `settings.IMAGE_STORE_BACKEND` - set which class to use for image storage (if any).
    2. `settings.IMAGE_STORE_CONFIG` - configuration values such as API credentials. 
- Implemented IMM backend that uploads the image to the course image library, creates a collection to hold the image, and returns a manifest URL pointing to that collection. The manifest URL is then saved to the target object in annotationsx.
- Modified the **Create New Source** form so that a file input appears on the form if this functionality is enabled, otherwise the user will be required to input a manifest URL as per usual. 

@dodget Can you take a look at this when you have a chance?

