### PR TITLE
Fix error when re-launching as a different user

### DIFF
--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -119,7 +119,9 @@ def launch_lti(request):
             user, lti_profile = create_new_user(anon_id=user_id, username=external_user_id, display_name=display_name, roles=roles, scope=user_scope)
             # log the user into the Django backend
         lti_profile.user.backend = 'django.contrib.auth.backends.ModelBackend'
+        saved_lti_launches = request.session['LTI_LAUNCH']
         login(request, lti_profile.user)
+        request.session.setdefault('LTI_LAUNCH', saved_lti_launches)
         save_session(
             request,
             user_id=user_id,


### PR DESCRIPTION
This fixes an issue impacting admins who attempt to re-launch the tool as a different user (e.g. "Act As" another user in Canvas).

The source of the problem is that the django app attempts to `login()` admin users (not students) so that they can edit assignments, etc, but because the user is different than what was in the session previously, the session is flushed before logging in the new user. This causes a subsequent error when the app tries to access LTI launch data: `Invalid LTI session: missing LTI_LAUNCH dict`. The workaround here is to restore the launch data after the login.
