### PR TITLE
Disable multi-file uploads until it is sorted in image backend.

### DIFF
--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -295,7 +295,7 @@
 		<div id="id_image_store" style="display:none;">
 			<div id="id_form_group_image_upload" class="form-group" style="padding: 10px 40px 10px 0px;">
 				<label for="id_image_upload">Source Image (PNG, JPG)</label>
-				<input type="file" id="id_image_upload" name="target_file" accept=".jpg, .jpeg, .png" multiple>
+				<input type="file" id="id_image_upload" name="target_file" accept=".jpg, .jpeg, .png">
 				<div id="id_image_upload_preview">
 					<p>No files currently selected for upload. </p>
 				</div>


### PR DESCRIPTION
This PR meets the MVP to resolve the issue of multiple image file uploads not working by:
- removing the `multiple` attribute from the `input` tag for image uploads