### PR TITLE
Multiple file upload

### DIFF
--- a/target_object_database/forms.py
+++ b/target_object_database/forms.py
@@ -91,12 +91,13 @@ def handle_file_upload(data, files, lti_params):
         ValidationError
     '''
     title = "Annotation: %s" % data.get('target_title', 'Untitled Target Object')
-    uploaded_file = files['target_file']
+    # it is a MultiValueDict, and a list of values can be returned with getlist
+    list_of_files = files.getlist('target_file')
 
     try:
         image_backend_class = getattr(image_store.backends, settings.IMAGE_STORE_BACKEND)
         image_backend = image_backend_class(settings.IMAGE_STORE_BACKEND_CONFIG, lti_params)
-        manifest_url = image_backend.store([uploaded_file], title)
+        manifest_url = image_backend.store([file for file in list_of_files], title)
     except image_store.backends.ImageStoreBackendException as e:
         raise ValidationError("Error uploading image. Details: %s" % e)
 

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -295,7 +295,7 @@
 		<div id="id_image_store" style="display:none;">
 			<div id="id_form_group_image_upload" class="form-group" style="padding: 10px 40px 10px 0px;">
 				<label for="id_image_upload">Source Image (PNG, JPG)</label>
-				<input type="file" id="id_image_upload" name="target_file" accept=".jpg, .jpeg, .png">
+				<input type="file" id="id_image_upload" name="target_file" accept=".jpg, .jpeg, .png" multiple>
 				<div id="id_image_upload_preview">
 					<p>No files currently selected for upload. </p>
 				</div>


### PR DESCRIPTION
This PR allows users to upload multiple images to annotationsx by:
- updating syntax to retrieve a list of files from a MultiValueDict using `getlist`.
- reinstating the `multiple` attribute on the file input field