### PR TITLE
Fix missing ok/cancal buttons when deleting video annotations

### DIFF
--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -301,7 +301,7 @@
     	var parentId = annotation.parent;
 
     	button.confirmation({
-			sanitize: false,
+			sanitize: false,  // disabling sanitizer so that the ok/cancel buttons are rendered
 			title: "Would you like to delete your reply?",
 			container: "body",
 			onConfirm: function (){

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -301,6 +301,7 @@
     	var parentId = annotation.parent;
 
     	button.confirmation({
+			sanitize: false,
 			title: "Would you like to delete your reply?",
 			container: "body",
 			onConfirm: function (){

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -793,7 +793,7 @@
             };
         });
         jQuery('.parentAnnotation [data-toggle="confirmation"]').confirmation({
-            sanitize: false,
+            sanitize: false,  // disabling sanitizer so that the ok/cancel buttons are rendered
             title: "Would you like to delete your annotation?",
             container: 'body',
             placement: 'left',

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -793,6 +793,7 @@
             };
         });
         jQuery('.parentAnnotation [data-toggle="confirmation"]').confirmation({
+            sanitize: false,
             title: "Would you like to delete your annotation?",
             container: 'body',
             placement: 'left',

--- a/hx_lti_initializer/static/vendors/development/bootstrap-confirmation.js
+++ b/hx_lti_initializer/static/vendors/development/bootstrap-confirmation.js
@@ -101,8 +101,8 @@
         '<h3 class="popover-title"></h3>' +
         '<div class="popover-content text-center">'+
           '<div class="btn-group">'+
-            '<a class="btn bs-confirmation-apply"></a>'+
-            '<a class="btn bs-confirmation-dismiss"></a>'+
+            '<a class="btn" data-apply="confirmation"></a>'+
+            '<a class="btn" data-dismiss="confirmation"></a>'+
           '</div>'+
         '</div>'+
       '</div>'
@@ -141,7 +141,7 @@
     $tip.find('.popover-title')[o.html ? 'html' : 'text'](this.getTitle());
 
     // configure 'ok' button
-    $tip.find('.bs-confirmation-apply')
+    $tip.find('[data-apply="confirmation"]')
       .addClass(o.btnOkClass)
       .html(o.btnOkLabel)
       .prepend($('<i></i>').addClass(o.btnOkIcon), ' ')
@@ -154,14 +154,14 @@
 
     // add href to confirm button if needed
     if (o.href && o.href != "#") {
-      $tip.find('.bs-confirmation-apply').attr({
+      $tip.find('[data-apply="confirmation"]').attr({
         href: o.href,
         target: o.target
       });
     }
 
     // configure 'cancel' button
-    $tip.find('.bs-confirmation-dismiss')
+    $tip.find('[data-dismiss="confirmation"]')
       .addClass(o.btnCancelClass)
       .html(o.btnCancelLabel)
       .prepend($('<i></i>').addClass(o.btnCancelIcon), ' ')

--- a/hx_lti_initializer/static/vendors/development/bootstrap-confirmation.js
+++ b/hx_lti_initializer/static/vendors/development/bootstrap-confirmation.js
@@ -101,8 +101,8 @@
         '<h3 class="popover-title"></h3>' +
         '<div class="popover-content text-center">'+
           '<div class="btn-group">'+
-            '<a class="btn" data-apply="confirmation"></a>'+
-            '<a class="btn" data-dismiss="confirmation"></a>'+
+            '<a class="btn bs-confirmation-apply"></a>'+
+            '<a class="btn bs-confirmation-dismiss"></a>'+
           '</div>'+
         '</div>'+
       '</div>'
@@ -141,7 +141,7 @@
     $tip.find('.popover-title')[o.html ? 'html' : 'text'](this.getTitle());
 
     // configure 'ok' button
-    $tip.find('[data-apply="confirmation"]')
+    $tip.find('.bs-confirmation-apply')
       .addClass(o.btnOkClass)
       .html(o.btnOkLabel)
       .prepend($('<i></i>').addClass(o.btnOkIcon), ' ')
@@ -154,14 +154,14 @@
 
     // add href to confirm button if needed
     if (o.href && o.href != "#") {
-      $tip.find('[data-apply="confirmation"]').attr({
+      $tip.find('.bs-confirmation-apply').attr({
         href: o.href,
         target: o.target
       });
     }
 
     // configure 'cancel' button
-    $tip.find('[data-dismiss="confirmation"]')
+    $tip.find('.bs-confirmation-dismiss')
       .addClass(o.btnCancelClass)
       .html(o.btnCancelLabel)
       .prepend($('<i></i>').addClass(o.btnCancelIcon), ' ')


### PR DESCRIPTION
This PR fixes an issue with the delete confirmation in the video annotation UI in which the ok/cancel buttons are not being rendered. 

| ![delete-notworking](https://user-images.githubusercontent.com/1165361/92532095-8b0b1280-f1fd-11ea-950b-43116a69cea5.png) | ![delete-fixed](https://user-images.githubusercontent.com/1165361/92532106-9100f380-f1fd-11ea-8701-90376f1a1264.png) |
|-----|-----|


The issue is that the confirmation library expects the buttons to have data attributes when rendered, so that it can query them to add the labels, but the data attributes are missing when the template is actually rendered. The popover library was updated in [3.4.1](https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/) to sanitize HTML attributes, so this PR disables the sanitizer for the two delete confirmations (deleting an annotation and deleting a reply).

Note that the annotation tool as a whole is transitioning away from the `bootstrap-confirmation` library in favor of `jquery-confirm` (used by Hxighlighter for text/image annotation).

Also, this has been deployed to the DEV environment for testing (seems to work as expected, although I did have to clear my cache).

@dodget @joshuagetega 

---
See also: [ATGU-2567](https://jira.huit.harvard.edu/browse/ATGU-2567)