### PR TITLE
Update image store

### DIFF
--- a/annotationsx/requirements/base.txt
+++ b/annotationsx/requirements/base.txt
@@ -21,4 +21,4 @@ requests==2.21.0
 six==1.12.0
 urllib3==1.24.2
 mock==1.3.0
-git+https://github.com/Harvard-ATG/media_management_sdk.git@develop#egg=media_management_sdk==0.1
+git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.1.0#egg=media_management_sdk==0.1.0

--- a/annotationsx/requirements/base.txt
+++ b/annotationsx/requirements/base.txt
@@ -7,6 +7,7 @@ django-bootstrap3==12.0.3
 django-braces==1.13.0
 django-crispy-forms==1.9.0
 django-extensions==2.1.6
+django-sslserver==0.22
 djangorestframework==3.9.2
 httplib2==0.12.1
 idna==2.8
@@ -20,3 +21,4 @@ requests==2.21.0
 six==1.12.0
 urllib3==1.24.2
 mock==1.3.0
+git+https://github.com/Harvard-ATG/media_management_sdk.git@develop#egg=media_management_sdk==0.1

--- a/annotationsx/settings/base.py
+++ b/annotationsx/settings/base.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = (
     'django_extensions',
     'bootstrap3',
     'crispy_forms',
+    'sslserver',
     'hx_lti_initializer',
     'annotation_store',
     'hx_lti_assignment',

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -79,6 +79,9 @@ class IMMImageStoreBackend(ImageStoreBackend):
 
     def store(self, uploaded_files, title):
         ''' Returns URL to a IIIF manifest containing the images. '''
+        if not uploaded_files or len(uploaded_files) == 0:
+            return None
+
         manifest_url = None
         try:
             # authenticate and ensure course space exists
@@ -108,7 +111,7 @@ class IMMImageStoreBackend(ImageStoreBackend):
             )
 
             # get IIIF manifest URL for collection
-            collection = self.client.api.get_collection(collection['id'])
+            collection = self.client.api.get_collection(collection_id=collection['id'])
             manifest_url = collection.get('iiif_manifest', {}).get('url')
             logger.info("User %s obtained manifest for collection: %s" % (self.user_id, collection))
 

--- a/image_store/tests.py
+++ b/image_store/tests.py
@@ -3,7 +3,7 @@ import json
 import html
 from unittest.mock import Mock, patch
 
-from . import backends 
+from . import backends
 
 ImageStoreBackend = backends.ImageStoreBackend
 ImageStoreBackendException = backends.ImageStoreBackendException
@@ -18,19 +18,19 @@ class TestImageStoreBackend(unittest.TestCase):
 class TestIMMImageStoreBackend(unittest.TestCase):
     def setUp(self):
         self.config = {
-            'base_url': 'http://media-management-api.localhost/api', 
-            'client_id': 'my-client-id', 
-            'client_secret': 'my-secret', 
+            'base_url': 'http://media-management-api.localhost/api',
+            'client_id': 'my-client-id',
+            'client_secret': 'my-secret',
         }
         self.user_id = 'aaaabbbb'
         self.lti_params = {
-            'tool_consumer_instance_guid': '7db438071375c02373713c12c73869ff2f470b68.harvard.instructure.com', 
+            'tool_consumer_instance_guid': '7db438071375c02373713c12c73869ff2f470b68.harvard.instructure.com',
             'tool_consumer_instance_name': 'Harvard University',
             'context_id': '9a8b2d3fa51ef413d19e480fb6c2ab091b7866a9',
             'context_label': 'demo-foo',
             'context_title': 'Foo&#39;s Demo Course',
-            'lis_course_offering_sourcedid': 'demo-foo', 
-            'lis_person_sourcedid': self.user_id, 
+            'lis_course_offering_sourcedid': 'demo-foo',
+            'lis_person_sourcedid': self.user_id,
             'custom_canvas_course_id': '11223344',
         }
 
@@ -53,15 +53,6 @@ class TestIMMImageStoreBackend(unittest.TestCase):
         self.assertEqual(self.lti_params['lis_course_offering_sourcedid'], backend.course_attrs['sis_course_id'])
         self.assertEqual(self.lti_params['custom_canvas_course_id'], backend.course_attrs['canvas_course_id'])
 
-        # check initial headers
-        self.assertTrue(hasattr(backend, 'headers'))
-        expected_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
-        self.assertEqual(expected_headers, backend.headers)
-
-    
     def test_constructor_missing_required_config(self):
         with self.assertRaises(ImageStoreBackendException):
             config = {}
@@ -95,13 +86,13 @@ class TestIMMImageStoreBackend(unittest.TestCase):
         }
         mock_post.return_value = Mock(ok=True, status_code=200)
         mock_post.return_value.json.return_value = response_data
-        
+
         backend = IMMImageStoreBackend(self.config, self.lti_params)
         actual_access_token = backend._obtain_token(course_id=None)
 
         mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
         self.assertEqual(response_data["access_token"], actual_access_token)
-        
+
     @patch('image_store.backends.requests.post')
     def test_create_course(self, mock_post):
         request_url = "%s/courses" % self.config['base_url']

--- a/image_store/tests.py
+++ b/image_store/tests.py
@@ -1,7 +1,9 @@
 import unittest
-import json
+import logging
 import html
 from unittest.mock import Mock, patch
+
+import media_management_sdk
 
 from . import backends
 
@@ -22,7 +24,7 @@ class TestIMMImageStoreBackend(unittest.TestCase):
             'client_id': 'my-client-id',
             'client_secret': 'my-secret',
         }
-        self.user_id = 'aaaabbbb'
+        self.user_id = 'a1b2c3d4'
         self.lti_params = {
             'tool_consumer_instance_guid': '7db438071375c02373713c12c73869ff2f470b68.harvard.instructure.com',
             'tool_consumer_instance_name': 'Harvard University',
@@ -33,25 +35,28 @@ class TestIMMImageStoreBackend(unittest.TestCase):
             'lis_person_sourcedid': self.user_id,
             'custom_canvas_course_id': '11223344',
         }
+        logging.disable(logging.CRITICAL)  # only show CRITICAL log events during test
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)  # restores logging
 
     def test_constructor(self):
         backend = IMMImageStoreBackend(self.config, self.lti_params)
 
         # check configuration
-        self.assertEqual(self.config['base_url'], backend.base_url)
-        self.assertEqual(self.config['client_id'], backend.client_id)
-        self.assertEqual(self.config['client_secret'], backend.client_secret)
+        self.assertEqual(self.config['base_url'], backend.client.base_url)
+        self.assertEqual(self.config['client_id'], backend.client.client_id)
+        self.assertEqual(self.config['client_secret'], backend.client.client_secret)
 
         # check lti params
         self.assertEqual(self.lti_params['lis_person_sourcedid'], backend.user_id)
         self.assertTrue(hasattr(backend, 'course_attrs'))
         self.assertEqual(self.lti_params['tool_consumer_instance_guid'], backend.course_attrs['lti_tool_consumer_instance_guid'])
-        self.assertEqual(self.lti_params['tool_consumer_instance_name'], backend.course_attrs['lti_tool_consumer_instance_name'])
         self.assertEqual(self.lti_params['context_id'], backend.course_attrs['lti_context_id'])
         self.assertEqual(self.lti_params['context_label'], backend.course_attrs['lti_context_label'])
         self.assertEqual(self.lti_params['context_title'], backend.course_attrs['lti_context_title'])
         self.assertEqual(self.lti_params['lis_course_offering_sourcedid'], backend.course_attrs['sis_course_id'])
-        self.assertEqual(self.lti_params['custom_canvas_course_id'], backend.course_attrs['canvas_course_id'])
+        self.assertEqual(int(self.lti_params['custom_canvas_course_id']), int(backend.course_attrs['canvas_course_id']))
 
     def test_constructor_missing_required_config(self):
         with self.assertRaises(ImageStoreBackendException):
@@ -65,164 +70,79 @@ class TestIMMImageStoreBackend(unittest.TestCase):
             lti_params = {"context_id": "foocontext123"}
             backend = IMMImageStoreBackend(config, lti_params)
 
-    @patch('image_store.backends.requests.post')
-    def test_obtain_token(self, mock_post):
-        request_url = "%s/auth/obtain-token" % self.config['base_url']
-        request_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
+    def test_store_called_with_no_uploaded_files(self):
+        backend = IMMImageStoreBackend(self.config, self.lti_params)
+        manifest_url = backend.store(uploaded_files=[], title=None)
+        self.assertEqual(manifest_url, None)
+
+    def test_store_raises_exception_if_auth_fails(self):
+        mock_client = Mock(
+            authenticate=Mock(side_effect=media_management_sdk.exceptions.ApiError)
+        )
+        with self.assertRaises(ImageStoreBackendException):
+            backend = IMMImageStoreBackend(self.config, self.lti_params)
+            backend.client = mock_client
+            backend.store(uploaded_files=[Mock(name="testfile.jpg")], title=None)
+
+    def test_store_returns_manifest_url(self):
+        course_response = {"id": 999}
+        images_response = [{"id": 111}]
+        collection_response = {
+            "id": 222,
+            "iiif_manifest": {"url": "http://localhost:8000/api/iiif/manifest/222"}
         }
-        request_data = {
-            "client_id": self.config['client_id'],
-            "client_secret": self.config['client_secret'],
-            "user_id": self.user_id,
-        }
-        response_data = {
-            "course_id": None,
-            "user_id": self.user_id,
-            "access_token": 'ABC-123423asdfascxwQRW-AAAA',
-            "expires": "2030-01-03 15:35:49",
-            "course_permission": None
-        }
-        mock_post.return_value = Mock(ok=True, status_code=200)
-        mock_post.return_value.json.return_value = response_data
+        title = "Untitled Test"
+
+        mock_file = Mock(
+            name="testfile.jpg",
+            file=None,
+            content_type="image/jpeg",
+        )
+        mock_api = Mock(
+            upload_images=Mock(return_value=images_response),
+            create_collection=Mock(return_value=collection_response),
+            get_collection=Mock(return_value=collection_response),
+        )
+        mock_client = Mock(
+            api=mock_api,
+            find_or_create_course=Mock(return_value=course_response),
+            authenticate=Mock(),
+        )
 
         backend = IMMImageStoreBackend(self.config, self.lti_params)
-        actual_access_token = backend._obtain_token(course_id=None)
+        backend.client = mock_client
+        manifest_url = backend.store(uploaded_files=[mock_file], title=title)
 
-        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
-        self.assertEqual(response_data["access_token"], actual_access_token)
+        self.assertEqual(manifest_url, collection_response["iiif_manifest"]["url"])
 
-    @patch('image_store.backends.requests.post')
-    def test_create_course(self, mock_post):
-        request_url = "%s/courses" % self.config['base_url']
-        request_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": "Token Fake123",
-        }
-        request_data = {
-            "lti_context_id": self.lti_params['context_id'],
-            "lti_tool_consumer_instance_guid": self.lti_params['tool_consumer_instance_guid'],
-            "lti_tool_consumer_instance_name": self.lti_params['tool_consumer_instance_name'],
-            "lti_context_title": self.lti_params['context_title'],
-            "lti_context_label": self.lti_params['context_label'],
-            "title": html.unescape(self.lti_params['context_title']),
-            "sis_course_id": self.lti_params['lis_course_offering_sourcedid'],
-            "canvas_course_id": self.lti_params['custom_canvas_course_id'],
-        }
-        response_data = {
-            "id": 101,
-            "created": "2020-01-16T20:34:42.887005Z",
-            "updated": "2020-01-16T20:34:42.887032Z",
-        }
-        response_data.update(request_data)
-
-        mock_post.return_value = Mock(ok=True, status_code=201)
-        mock_post.return_value.json.return_value = response_data
-
-        backend = IMMImageStoreBackend(self.config, self.lti_params)
-        backend.headers = request_headers
-        actual_data = backend._create_course()
-
-        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
-        self.assertEqual(response_data, actual_data)
-
-    @patch('image_store.backends.requests.post')
-    def test_create_collection(self, mock_post):
-        course_id = 123
-        title = "Image Annotation"
-        request_url = "%s/courses/%s/collections" % (self.config['base_url'], course_id)
-        request_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": "Token Fake123",
-        }
-        request_data = {
-            "title": title,
-            "description": "Image Annotation"
-        }
-        response_data = {
-            "id": 901,
-            "created": "2020-01-16T20:34:42.887005Z",
-            "updated": "2020-01-16T20:34:42.887005Z",
-            "title": request_data['title'],
-            "description": request_data['description'],
-            "course_id": course_id,
-            "course_image_ids": [],
-            "iiif_manifest": {
-                "source": "images",
-                "canvas_id": "",
-                "url": "%s/iiif/manifest/641" % self.config['base_url']
-            },
-        }
-
-        mock_post.return_value = Mock(ok=True, status_code=201)
-        mock_post.return_value.json.return_value = response_data
-
-        backend = IMMImageStoreBackend(self.config, self.lti_params)
-        backend.headers = request_headers
-        actual_data = backend._create_collection(course_id, title)
-
-        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
-        self.assertEqual(response_data, actual_data)
-
-    @patch('image_store.backends.requests.get')
-    def test_get_collection(self, mock_get):
-        collection_id = 555
-        request_url = "%s/collections/%s" % (self.config['base_url'], collection_id)
-        request_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": "Token Fake123",
-        }
-        response_data = {
-            "id": collection_id,
-            "created": "2020-01-16T20:34:42.887005Z",
-            "updated": "2020-01-16T20:34:42.887005Z",
-            "title": "Test Collection",
-            "description": "",
-            "course_id": 123,
-            "course_image_ids": [],
-            "iiif_manifest": {
-                "source": "images",
-                "canvas_id": "",
-                "url": "%s/iiif/manifest/%s" % (self.config['base_url'], collection_id)
-            },
-        }
-
-        mock_get.return_value = Mock(ok=True, status_code=200)
-        mock_get.return_value.json.return_value = response_data
-
-        backend = IMMImageStoreBackend(self.config, self.lti_params)
-        backend.headers = request_headers
-        actual_data = backend._get_collection(collection_id)
-
-        mock_get.assert_called_with(request_url, headers=request_headers)
-        self.assertEqual(response_data, actual_data)
-
-    @patch('image_store.backends.requests.post')
-    def test_add_to_collection(self, mock_post):
-        collection_id = 555
-        image_ids = [100,101,102]
-        request_url = "%s/collections/%s/images" % (self.config['base_url'], collection_id)
-        request_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": "Token Fake123",
-        }
-        request_data = [dict(course_image_id=image_id) for image_id in image_ids]
-        response_data = [{
-            "id": idx,
-            "collection_id": collection_id,
-            "course_image_id": image_id,
-            } for idx, image_id in enumerate(image_ids)]
-        mock_post.return_value = Mock(ok=True, status_code=201)
-        mock_post.return_value.json.return_value = response_data
-
-        backend = IMMImageStoreBackend(self.config, self.lti_params)
-        backend.headers = request_headers
-        actual_data = backend._add_to_collection(collection_id, image_ids)
-
-        mock_post.assert_called_with(request_url, headers=request_headers, data=json.dumps(request_data))
-        self.assertEqual(response_data, actual_data)
+        mock_client.authenticate.assert_called_with(
+            user_id=self.user_id
+        )
+        mock_client.find_or_create_course.assert_called_with(
+            lti_context_id=self.lti_params["context_id"],
+            lti_tool_consumer_instance_guid=self.lti_params["tool_consumer_instance_guid"],
+            lti_context_title=self.lti_params["context_title"],
+            lti_context_label=self.lti_params["context_label"],
+            title=html.unescape(self.lti_params["context_title"]),
+            canvas_course_id=int(self.lti_params["custom_canvas_course_id"]),
+            sis_course_id=self.lti_params["lis_course_offering_sourcedid"],
+        )
+        mock_client.api.upload_images.assert_called_with(
+            course_id=course_response["id"],
+            upload_files=[(mock_file.name, mock_file.file, mock_file.content_type)],
+            title=title,
+        )
+        mock_client.api.create_collection.assert_called_with(
+            course_id=course_response["id"],
+            title=title,
+            description='',
+        )
+        mock_client.api.update_collection.assert_called_with(
+            collection_id=collection_response["id"],
+            course_id=course_response["id"],
+            course_image_ids=[image['id'] for image in images_response],
+            title=title,
+        )
+        mock_client.api.get_collection.assert_called_with(
+            collection_id=collection_response["id"],
+        )

--- a/target_object_database/forms.py
+++ b/target_object_database/forms.py
@@ -97,7 +97,7 @@ def handle_file_upload(data, files, lti_params):
     try:
         cls = image_store.backends.get_backend_class(settings.IMAGE_STORE_BACKEND)
         image_backend = cls(config=settings.IMAGE_STORE_BACKEND_CONFIG, lti_params=lti_params)
-        manifest_url = image_backend.store(list_of_files, title)
+        manifest_url = image_backend.store([file for file in list_of_files], title) # Intentionally passed as a list() instead of MultiValueDict
     except image_store.backends.ImageStoreBackendException as e:
         raise ValidationError("Error uploading image. Details: %s" % e)
 

--- a/target_object_database/forms.py
+++ b/target_object_database/forms.py
@@ -43,7 +43,7 @@ class SourceForm(forms.ModelForm):
             validate_https_url(target_content)
         except ValidationError as e:
             self.add_error('target_content', 'Not a valid manifest URL. Make sure it\'s only one URL and that it begins with "https".')
-    
+
     def validate_manifest_unique(self, target_content):
         found = None
         try:
@@ -83,10 +83,10 @@ def handle_file_upload(data, files, lti_params):
         data(dict): the request.POST dict-like object
         files(dict): the request.FILES dict-like object
         lti_params(dict): should be the initial LTI launch params stored in th session
-    
+
     Returns:
         str: the manifest URL
-    
+
     Raises:
         ValidationError
     '''
@@ -95,9 +95,9 @@ def handle_file_upload(data, files, lti_params):
     list_of_files = files.getlist('target_file')
 
     try:
-        image_backend_class = getattr(image_store.backends, settings.IMAGE_STORE_BACKEND)
-        image_backend = image_backend_class(settings.IMAGE_STORE_BACKEND_CONFIG, lti_params)
-        manifest_url = image_backend.store([file for file in list_of_files], title)
+        cls = image_store.backends.get_backend_class(settings.IMAGE_STORE_BACKEND)
+        image_backend = cls(config=settings.IMAGE_STORE_BACKEND_CONFIG, lti_params=lti_params)
+        manifest_url = image_backend.store(list_of_files, title)
     except image_store.backends.ImageStoreBackendException as e:
         raise ValidationError("Error uploading image. Details: %s" % e)
 


### PR DESCRIPTION
This PR refactors the `image_store` to use the [media_management_sdk](https://github.com/Harvard-ATG/media_management_sdk) library.

Notes:
- This is not intended to change the existing behavior, since we are just swapping out the implementation of the API calls.
- The unit tests for the API calls are now the responsibility of the `media_management_sdk` library, so most of those have been removed. 
- This has been deployed to DEV for testing.