### PR TITLE
upgrade django 3.0

### DIFF
--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 {% bootstrap_javascript %}
 

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment_hxighlighter.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment_hxighlighter.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 {% bootstrap_javascript %}
 

--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.core import serializers
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, QueryDict
-from django.shortcuts import get_object_or_404, redirect, render, render_to_response
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from hx_lti_assignment.forms import (
     AssignmentForm,

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         {% block beginningscripts %}{% endblock %}
-        {% load staticfiles %}
+        {% load static %}
         {% load list_of_ids %}
         {# Load the tag library #}
         {% load bootstrap3 %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/base.html
@@ -4,7 +4,7 @@
     <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     {% load bootstrap3 %}
-    {% load staticfiles %}
+    {% load static %}
     {% load hx_lti_initializer_extras %}
     <link rel="stylesheet" href="{% static "vendors/development/css/font-awesome.css" %}">
     <link rel="stylesheet" type="text/css" href="{% static "vendors/development/css/bootstrap-select.css" %}">

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/base.html' %}
 {% load hx_lti_initializer_extras %}
-{% load static from staticfiles %} 
+{% load static %} 
 {# Load the tag library #} 
 {% load bootstrap3 %}
 {# Display django.contrib.messages as Bootstrap alerts #} 

--- a/hx_lti_initializer/templates/hx_lti_initializer/embed_lti_selection.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/embed_lti_selection.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 <!DOCTYPE html>
 <html lang="en">

--- a/hx_lti_initializer/templates/hx_lti_initializer/hxighlighter_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/hxighlighter_base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        {% load staticfiles %}
+        {% load static %}
         {% load list_of_ids %}
         {# Load the tag library #}
         {% load hx_lti_initializer_extras %}

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 {% block beginningscripts %}
 <script src="{% static "vendors/development/jquery-1.9.1.js" %}"></script>

--- a/hx_lti_initializer/templates/ig/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/ig/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 {% block beginningscripts %}
 <script src="{% static "vendors/development/jquery-1.12.4.js" %}"></script>

--- a/hx_lti_initializer/templates/tx/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/tx/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block beginningscripts %}

--- a/hx_lti_initializer/templates/vd/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/vd/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.core.exceptions import MultipleObjectsReturned, PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.2.13
+Django==3.0.0
 channels==2.4.0
 channels_redis==2.4.2
 coverage==5.0

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/base.html' %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 
 {% block css_file %}
 <style type="text/css">

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -9,7 +9,6 @@ from django.shortcuts import (  # noqa
     get_object_or_404,
     redirect,
     render,
-    render_to_response,
 )
 from django.urls import reverse
 from django.utils.html import escape


### PR DESCRIPTION
Update django 2.2.13 to 3.0.0
- change `{% load staticfiles %}` to `{% load static %}`
- updated `django.contrib.staticfiles.templatetags.staticfiles` to `django.templatetags.static`
- removed `render_to_response` 

Note: Failing test before the django upgrade(tested on master branch with django 2.2.13)
https://github.com/Harvard-ATG/hxat/blob/5770378c105cf00b74558f3773e6ddddaba31f4c/notification/tests/test_consumer.py#L149
https://github.com/Harvard-ATG/hxat/blob/5770378c105cf00b74558f3773e6ddddaba31f4c/notification/tests/test_consumer.py#L89
